### PR TITLE
Add WooCommerce bulk management actions

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -292,11 +292,83 @@ case 'save_product':
      }
   }
   echo json_encode(array('success'=>true));
-  $db->close();
-  break;
- case 'analytics':
+   $db->close();
+   break;
+
+case 'bulk_stock':
   $db = connect(); if(!$db) break;
   $prefix = $_SESSION['db']['prefix'];
+  $status = ($_POST['status'] ?? '') === 'instock' ? 'instock' : 'outofstock';
+  $db->query("UPDATE {$prefix}postmeta SET meta_value='$status' WHERE meta_key='_stock_status'");
+  $db->query("INSERT INTO {$prefix}postmeta (post_id,meta_key,meta_value) SELECT ID,'_stock_status','$status' FROM {$prefix}posts p WHERE p.post_type='product' AND NOT EXISTS (SELECT 1 FROM {$prefix}postmeta pm WHERE pm.post_id=p.ID AND pm.meta_key='_stock_status')");
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+case 'bulk_price':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $op = ($_POST['op'] ?? '') === 'dec' ? '-' : '+';
+  $type = ($_POST['type'] ?? '') === 'fixed' ? 'fixed' : 'percent';
+  $val = isset($_POST['value']) ? floatval($_POST['value']) : 0;
+  if($val==0){ echo json_encode(array('success'=>false,'message'=>'مقدار نامعتبر')); $db->close(); break; }
+  if($type==='percent'){
+    $factor = $op==='+' ? (1 + $val/100) : (1 - $val/100);
+    $db->query("UPDATE {$prefix}postmeta SET meta_value=ROUND(CAST(meta_value AS DECIMAL(10,2))*$factor,2) WHERE meta_key IN ('_price','_regular_price')");
+  }else{
+    $sign = $op==='+' ? '+' : '-';
+    $db->query("UPDATE {$prefix}postmeta SET meta_value=ROUND(CAST(meta_value AS DECIMAL(10,2)) $sign $val,2) WHERE meta_key IN ('_price','_regular_price')");
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+case 'bulk_seo_keywords':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $hasIndexTable = $db->query("SHOW TABLES LIKE '{$prefix}yoast_indexable'");
+  $updateIndex = $hasIndexTable && $hasIndexTable->num_rows > 0;
+  $products = $db->query("SELECT ID,post_title FROM {$prefix}posts WHERE post_type='product'");
+  if($products){
+    while($p=$products->fetch_assoc()){
+      $id = intval($p['ID']);
+      $title = $db->real_escape_string($p['post_title']);
+      $db->query("DELETE FROM {$prefix}postmeta WHERE post_id=$id AND meta_key IN ('_yoast_wpseo_metakeywords','_yoast_wpseo_focuskw')");
+      $db->query("INSERT INTO {$prefix}postmeta(post_id,meta_key,meta_value) VALUES ($id,'_yoast_wpseo_metakeywords','$title'),($id,'_yoast_wpseo_focuskw','$title')");
+      if($updateIndex){
+        $db->query("UPDATE {$prefix}yoast_indexable SET primary_focus_keyword='$title', meta_keywords='$title' WHERE object_id=$id AND object_type='post'");
+      }
+    }
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+case 'bulk_seo_desc':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $hasIndexTable = $db->query("SHOW TABLES LIKE '{$prefix}yoast_indexable'");
+  $updateIndex = $hasIndexTable && $hasIndexTable->num_rows > 0;
+  $products = $db->query("SELECT ID,post_title FROM {$prefix}posts WHERE post_type='product'");
+  if($products){
+    while($p=$products->fetch_assoc()){
+      $id = intval($p['ID']);
+      $title = $db->real_escape_string($p['post_title']);
+      $desc  = $db->real_escape_string("خرید $title با بهترین قیمت از فروشگاه ما.");
+      $db->query("DELETE FROM {$prefix}postmeta WHERE post_id=$id AND meta_key='_yoast_wpseo_metadesc'");
+      $db->query("INSERT INTO {$prefix}postmeta(post_id,meta_key,meta_value) VALUES ($id,'_yoast_wpseo_metadesc','$desc')");
+      if($updateIndex){
+        $db->query("UPDATE {$prefix}yoast_indexable SET description='$desc' WHERE object_id=$id AND object_type='post'");
+      }
+    }
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+  case 'analytics':
+   $db = connect(); if(!$db) break;
+   $prefix = $_SESSION['db']['prefix'];
   $catRes = $db->query("SELECT COALESCE(pt.name,t.name) name,COUNT(tr.object_id) c FROM {$prefix}terms t JOIN {$prefix}term_taxonomy tt ON t.term_id=tt.term_id LEFT JOIN {$prefix}term_taxonomy ptt ON tt.parent=ptt.term_taxonomy_id LEFT JOIN {$prefix}terms pt ON ptt.term_id=pt.term_id JOIN {$prefix}term_relationships tr ON tr.term_taxonomy_id=tt.term_taxonomy_id WHERE tt.taxonomy='product_cat' GROUP BY name");
   $cat = array('labels'=>array(),'data'=>array());
   if($catRes){ while($r=$catRes->fetch_assoc()){ $cat['labels'][]=$r['name']; $cat['data'][]=$r['c']; }}

--- a/index.php
+++ b/index.php
@@ -165,6 +165,9 @@ $('#connect-btn').click(function(){
   <li class="nav-item" role="presentation">
     <button class="nav-link" data-bs-toggle="tab" data-bs-target="#settings" type="button">تنظیمات</button>
   </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" data-bs-toggle="tab" data-bs-target="#bulk" type="button">اقدامات دست‌جمعی</button>
+  </li>
 </ul>
 <div class="tab-content mt-4">
 <div class="tab-pane fade show active p-3" id="products">
@@ -274,8 +277,51 @@ $('#connect-btn').click(function(){
       </div>
     </div>
   </div>
+  </div>
 </div>
 </div>
+<div class="tab-pane fade p-3" id="bulk">
+  <div class="card mb-3">
+    <div class="card-header">مدیریت موجودی</div>
+    <div class="card-body">
+      <p class="text-muted small">موجود یا ناموجود کردن همه محصولات. این کار باعث جلوگیری از خرید در زمان تغییر قیمت می‌شود.</p>
+      <button class="btn btn-success me-2" id="bulkStockIn">موجود کردن همه محصولات</button>
+      <button class="btn btn-danger" id="bulkStockOut">ناموجود کردن همه محصولات</button>
+    </div>
+  </div>
+  <div class="card mb-3">
+    <div class="card-header">تغییر قیمت دسته‌جمعی</div>
+    <div class="card-body">
+      <div class="row g-2 align-items-end">
+        <div class="col-md-3">
+          <label class="form-label">مقدار</label>
+          <input type="number" id="bulkPriceVal" class="form-control">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">نوع</label>
+          <select id="bulkPriceType" class="form-select">
+            <option value="percent">درصد</option>
+            <option value="fixed">عدد ثابت</option>
+          </select>
+        </div>
+        <div class="col-md-6">
+          <button class="btn btn-success me-2" id="bulkPriceInc">افزایش قیمت</button>
+          <button class="btn btn-danger" id="bulkPriceDec">کاهش قیمت</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="card mb-3">
+    <div class="card-header">اقدامات دسته‌جمعی سئو</div>
+    <div class="card-body">
+      <div class="mb-3">
+        <button class="btn btn-primary" id="bulkSeoKeywords">کپی نام محصول در Meta Keywords</button>
+      </div>
+      <div class="mb-3">
+        <button class="btn btn-secondary" id="bulkSeoDesc">تولید توضیحات متا</button>
+      </div>
+    </div>
+  </div>
 </div>
 
  <footer class="bg-dark text-light mt-5">
@@ -739,6 +785,70 @@ setInterval(()=>{
 
 fetch('https://ipapi.co/json/').then(r=>r.json()).then(d=>{
   $('#ipInfo').html(`${d.ip} <img src="https://cdn.jsdelivr.net/npm/flag-icons@6.7.0/flags/4x3/${d.country_code.toLowerCase()}.svg" width="20" class="ms-1">`);
+});
+
+$('#bulkStockIn').click(function(){
+  Swal.fire({title:'آیا مطمئن هستید؟',text:'این کار باعث جلوگیری از خرید در زمان تغییر قیمت می‌شود.',icon:'warning',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_stock',status:'instock'},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('به‌روزرسانی شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
+});
+
+$('#bulkStockOut').click(function(){
+  Swal.fire({title:'آیا مطمئن هستید؟',text:'این کار باعث جلوگیری از خرید در زمان تغییر قیمت می‌شود.',icon:'warning',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_stock',status:'outofstock'},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('به‌روزرسانی شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
+});
+
+function bulkPrice(op){
+  const val=$('#bulkPriceVal').val();
+  if(!val){ toastr.error('مقدار را وارد کنید'); return; }
+  Swal.fire({title:'آیا مطمئن هستید؟',icon:'question',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_price',op:op,type:$('#bulkPriceType').val(),value:val},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('قیمت‌ها به‌روزرسانی شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
+}
+$('#bulkPriceInc').click(()=>bulkPrice('inc'));
+$('#bulkPriceDec').click(()=>bulkPrice('dec'));
+
+$('#bulkSeoKeywords').click(function(){
+  Swal.fire({title:'آیا مطمئن هستید؟',icon:'question',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_seo_keywords'},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('کلمات کلیدی به‌روزرسانی شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
+});
+
+$('#bulkSeoDesc').click(function(){
+  Swal.fire({title:'آیا مطمئن هستید؟',icon:'question',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_seo_desc'},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('توضیحات متا تولید شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
 });
 
 // Analytics charts with tables


### PR DESCRIPTION
## Summary
- Add "Bulk Actions" dashboard tab with inventory, price, and SEO utilities
- Implement confirmation dialogs and AJAX handlers for stock, price updates, and SEO meta fields
- Provide server-side endpoints to apply bulk changes across products
- Ensure bulk SEO updates also populate focus keywords and Yoast indexable fields

## Testing
- `php -l index.php`
- `php -l ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb249a21088325b64e1143b7d0ebff