### PR TITLE
Add profile dropdown and user log modal

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -5,6 +5,7 @@ header('Content-Type: application/json; charset=utf-8');
 $AUTH_TOKEN = '09128334246';
 $configFile = __DIR__.'/config.secure';
 require_once __DIR__.'/prompt_template.php';
+require_once __DIR__.'/classes/UserManager.php';
 $action = isset($_POST['action']) ? $_POST['action'] : '';
 
 if(!isset($_SESSION['auth']) && $action !== 'login'){
@@ -19,31 +20,20 @@ case 'login':
   if($token === $AUTH_TOKEN){
     $_SESSION['auth'] = true;
     $_SESSION['token'] = $token;
+    $_SESSION['user_id'] = 1;
+    $_SESSION['username'] = 'admin';
+    log_event('login');
     echo json_encode(array('success'=>true));
   } else {
     echo json_encode(array('success'=>false,'message'=>'توکن نامعتبر است'));
   }
   break;
- case 'logout':
+case 'logout':
+  log_event('logout');
   session_destroy();
   echo json_encode(array('success'=>true));
   break;
-case 'read_wp_config':
-  $config_path = dirname(__DIR__).'/wp-config.php';
-  if(file_exists($config_path)){
-    $config = file_get_contents($config_path);
-    preg_match("/define\(\s*'DB_NAME',\s*'([^']+)'\s*\)/", $config, $m); $name = isset($m[1]) ? $m[1] : '';
-    preg_match("/define\(\s*'DB_USER',\s*'([^']+)'\s*\)/", $config, $m); $user = isset($m[1]) ? $m[1] : '';
-    preg_match("/define\(\s*'DB_PASSWORD',\s*'([^']+)'\s*\)/", $config, $m); $pass = isset($m[1]) ? $m[1] : '';
-    preg_match("/define\(\s*'DB_HOST',\s*'([^']+)'\s*\)/", $config, $m); $host = isset($m[1]) ? $m[1] : 'localhost';
-    preg_match("/\$table_prefix\s*=\s*'([^']+)'/", $config, $m); $prefix = isset($m[1]) ? $m[1] : 'wp_';
-    secure_save_config(compact('host','name','user','pass','prefix'));
-    echo json_encode(array('success'=>true,'name'=>$name,'user'=>$user,'pass'=>$pass,'host'=>$host,'prefix'=>$prefix));
-  } else {
-    echo json_encode(array('success'=>false,'message'=>'فایل wp-config.php پیدا نشد'));
-  }
-  break;
- case 'db_connect':
+case 'db_connect':
   $host = isset($_POST['host']) ? $_POST['host'] : '';
   $name = isset($_POST['name']) ? $_POST['name'] : '';
   $user = isset($_POST['user']) ? $_POST['user'] : '';
@@ -97,6 +87,149 @@ case 'save_licenses':
   $licenses=isset($_POST['licenses'])?json_decode($_POST['licenses'],true):array();
   if(file_put_contents($path,json_encode($licenses,JSON_UNESCAPED_UNICODE))!==false){ echo json_encode(array('success'=>true)); }
   else{ echo json_encode(array('success'=>false,'message'=>'ذخیره نشد')); }
+  break;
+case 'local_db_connect':
+  $host = isset($_POST['host']) ? $_POST['host'] : '';
+  $name = isset($_POST['name']) ? $_POST['name'] : '';
+  $user = isset($_POST['user']) ? $_POST['user'] : '';
+  $pass = isset($_POST['pass']) ? $_POST['pass'] : '';
+  $prefix = isset($_POST['prefix']) ? $_POST['prefix'] : 'msw_';
+  try{ $mysqli = new mysqli($host,$user,$pass,$name); }
+  catch(mysqli_sql_exception $e){ echo json_encode(array('success'=>false,'message'=>$e->getMessage())); break; }
+  if($mysqli->connect_errno){ echo json_encode(array('success'=>false,'message'=>$mysqli->connect_error)); break; }
+  $mysqli->set_charset('utf8mb4');
+  $_SESSION['logdb']=array('host'=>$host,'name'=>$name,'user'=>$user,'pass'=>$pass,'prefix'=>$prefix);
+  secure_save_local_config($_SESSION['logdb']);
+  init_local_tables($mysqli,$prefix);
+  $mysqli->close();
+  echo json_encode(array('success'=>true));
+  break;
+case 'local_load_config':
+  $cfg = secure_load_local_config();
+  if($cfg){ echo json_encode(array('success'=>true,'host'=>$cfg['host'],'name'=>$cfg['name'],'user'=>$cfg['user'],'pass'=>$cfg['pass'],'prefix'=>$cfg['prefix'])); }
+  else{ echo json_encode(array('success'=>false)); }
+  break;
+case 'local_check_config':
+  $cfg = secure_load_local_config();
+  if(!$cfg){ echo json_encode(array('success'=>false,'message'=>'تنظیمات موجود نیست')); break; }
+  try{ $mysqli = new mysqli($cfg['host'],$cfg['user'],$cfg['pass'],$cfg['name']); }
+  catch(mysqli_sql_exception $e){ echo json_encode(array('success'=>false,'message'=>$e->getMessage())); break; }
+  if($mysqli->connect_errno){ echo json_encode(array('success'=>false,'message'=>$mysqli->connect_error)); }
+  else { $mysqli->close(); echo json_encode(array('success'=>true)); }
+  break;
+case 'fetch_user_logs':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $prefix = $_SESSION['logdb']['prefix'];
+  $uid = intval($_POST['id'] ?? 0);
+  $rows = array();
+  $stmt = $db->prepare("SELECT action, ip_address, timestamp FROM {$prefix}user_logs WHERE user_id=? ORDER BY id DESC LIMIT 100");
+  if($stmt){
+    $stmt->bind_param('i',$uid);
+    $stmt->execute();
+    $res=$stmt->get_result();
+    while($r=$res->fetch_assoc()){ $rows[] = array('action'=>$r['action'],'ip'=>$r['ip_address'],'ts'=>$r['timestamp']); }
+    $stmt->close();
+  }
+  $counts=array();
+  foreach($rows as $r){ $counts[$r['action']] = ($counts[$r['action']] ?? 0) + 1; }
+  $db->close();
+  echo json_encode(array('success'=>true,'data'=>$rows,'counts'=>$counts));
+  break;
+case 'admin_check':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false)); break; }
+  $prefix = $_SESSION['logdb']['prefix'];
+  $res = $db->query("SELECT COUNT(*) AS c FROM {$prefix}users WHERE role='admin'");
+  $row = $res ? $res->fetch_assoc() : array('c'=>0);
+  $db->close();
+  echo json_encode(array('success'=>true,'exists'=>$row['c']>0));
+  break;
+case 'admin_init':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $username = trim($_POST['username'] ?? '');
+  $password = $_POST['password'] ?? '';
+  if(!$username || !$password){ echo json_encode(array('success'=>false,'message'=>'نام کاربری و رمز عبور الزامی است')); $db->close(); break; }
+  $data = array(
+    'username'=>$username,
+    'password'=>$password,
+    'full_name'=>'',
+    'phone_number'=>'',
+    'role'=>'admin',
+    'status'=>'active',
+    'permissions'=>''
+  );
+  $ok = $mgr->create($data);
+  echo json_encode(array('success'=>$ok,'message'=>$ok?'':'خطا در ذخیره'));
+  $db->close();
+  break;
+case 'users_list':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db, $_SESSION['logdb']['prefix']);
+  echo json_encode(array('success'=>true,'data'=>$mgr->all()));
+  $db->close();
+  break;
+case 'user_get':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $id = intval($_POST['id'] ?? 0);
+  $data = $mgr->get($id);
+  if($data){ echo json_encode(array('success'=>true,'data'=>$data)); }
+  else { echo json_encode(array('success'=>false,'message'=>'کاربر یافت نشد')); }
+  $db->close();
+  break;
+case 'user_create':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $username = trim($_POST['username'] ?? '');
+  $password = $_POST['password'] ?? '';
+  if(!$username || !$password){ echo json_encode(array('success'=>false,'message'=>'نام کاربری و رمز عبور الزامی است')); $db->close(); break; }
+  $data = array(
+    'username'=>$username,
+    'password'=>$password,
+    'full_name'=>$_POST['full_name'] ?? '',
+    'phone_number'=>$_POST['phone_number'] ?? '',
+    'role'=>$_POST['role'] ?? 'user',
+    'status'=>$_POST['status'] ?? 'active',
+    'permissions'=>$_POST['permissions'] ?? ''
+  );
+  $ok = $mgr->create($data);
+  echo json_encode(array('success'=>$ok,'message'=>$ok?'':'خطا در ذخیره'));
+  $db->close();
+  break;
+case 'user_update':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $id = intval($_POST['id'] ?? 0);
+  $username = trim($_POST['username'] ?? '');
+  if(!$id || !$username){ echo json_encode(array('success'=>false,'message'=>'داده نامعتبر')); $db->close(); break; }
+  $data = array(
+    'username'=>$username,
+    'password'=>$_POST['password'] ?? '',
+    'full_name'=>$_POST['full_name'] ?? '',
+    'phone_number'=>$_POST['phone_number'] ?? '',
+    'role'=>$_POST['role'] ?? 'user',
+    'status'=>$_POST['status'] ?? 'active',
+    'permissions'=>$_POST['permissions'] ?? ''
+  );
+  $ok = $mgr->update($id,$data);
+  echo json_encode(array('success'=>$ok,'message'=>$ok?'':'خطا در ذخیره'));
+  $db->close();
+  break;
+case 'user_delete':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $id = intval($_POST['id'] ?? 0);
+  $ok = $mgr->delete($id);
+  echo json_encode(array('success'=>$ok,'message'=>$ok?'':'حذف نشد'));
+  $db->close();
   break;
 case 'list_products':
   $db = connect(); if(!$db) break;
@@ -249,6 +382,7 @@ case 'save_product':
   $id = intval($_POST['id']);
   $name = $db->real_escape_string($_POST['name']);
   $slug = $db->real_escape_string($_POST['slug']);
+  $old_slug = isset($_POST['old_slug']) ? $db->real_escape_string($_POST['old_slug']) : '';
   $desc = $db->real_escape_string($_POST['description']);
   $price = $db->real_escape_string($_POST['price']);
   $stock = $db->real_escape_string($_POST['stock_status']);
@@ -291,12 +425,95 @@ case 'save_product':
        }
      }
   }
+  $redirect_success = false;
+  if($old_slug && $old_slug !== $slug){
+    $check = $db->query("SHOW TABLES LIKE '{$prefix}yoast_redirects'");
+    if($check && $check->num_rows){
+      $oldPath = '/product/'.$old_slug.'/';
+      $newPath = '/product/'.$slug.'/';
+      if($db->query("INSERT INTO {$prefix}yoast_redirects (origin,target,type) VALUES ('$oldPath','$newPath','301')")){
+        $redirect_success = true;
+      }
+    }
+  }
+  echo json_encode(array('success'=>true,'redirect'=>$redirect_success));
+  $db->close();
+  break;
+
+case 'bulk_stock':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $status = ($_POST['status'] ?? '') === 'instock' ? 'instock' : 'outofstock';
+  $db->query("UPDATE {$prefix}postmeta SET meta_value='$status' WHERE meta_key='_stock_status'");
+  $db->query("INSERT INTO {$prefix}postmeta (post_id,meta_key,meta_value) SELECT ID,'_stock_status','$status' FROM {$prefix}posts p WHERE p.post_type='product' AND NOT EXISTS (SELECT 1 FROM {$prefix}postmeta pm WHERE pm.post_id=p.ID AND pm.meta_key='_stock_status')");
   echo json_encode(array('success'=>true));
   $db->close();
   break;
- case 'analytics':
+
+case 'bulk_price':
   $db = connect(); if(!$db) break;
   $prefix = $_SESSION['db']['prefix'];
+  $op = ($_POST['op'] ?? '') === 'dec' ? '-' : '+';
+  $type = ($_POST['type'] ?? '') === 'fixed' ? 'fixed' : 'percent';
+  $val = isset($_POST['value']) ? floatval($_POST['value']) : 0;
+  if($val==0){ echo json_encode(array('success'=>false,'message'=>'مقدار نامعتبر')); $db->close(); break; }
+  if($type==='percent'){
+    $factor = $op==='+' ? (1 + $val/100) : (1 - $val/100);
+    $db->query("UPDATE {$prefix}postmeta SET meta_value=ROUND(CAST(meta_value AS DECIMAL(10,2))*$factor,2) WHERE meta_key IN ('_price','_regular_price')");
+  }else{
+    $sign = $op==='+' ? '+' : '-';
+    $db->query("UPDATE {$prefix}postmeta SET meta_value=ROUND(CAST(meta_value AS DECIMAL(10,2)) $sign $val,2) WHERE meta_key IN ('_price','_regular_price')");
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+case 'bulk_seo_keywords':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $hasIndexTable = $db->query("SHOW TABLES LIKE '{$prefix}yoast_indexable'");
+  $updateIndex = $hasIndexTable && $hasIndexTable->num_rows > 0;
+  $products = $db->query("SELECT ID,post_title FROM {$prefix}posts WHERE post_type='product'");
+  if($products){
+    while($p=$products->fetch_assoc()){
+      $id = intval($p['ID']);
+      $title = $db->real_escape_string($p['post_title']);
+      $db->query("DELETE FROM {$prefix}postmeta WHERE post_id=$id AND meta_key IN ('_yoast_wpseo_metakeywords','_yoast_wpseo_focuskw')");
+      $db->query("INSERT INTO {$prefix}postmeta(post_id,meta_key,meta_value) VALUES ($id,'_yoast_wpseo_metakeywords','$title'),($id,'_yoast_wpseo_focuskw','$title')");
+      if($updateIndex){
+        $db->query("UPDATE {$prefix}yoast_indexable SET primary_focus_keyword='$title', meta_keywords='$title' WHERE object_id=$id AND object_type='post'");
+      }
+    }
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+case 'bulk_seo_desc':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $hasIndexTable = $db->query("SHOW TABLES LIKE '{$prefix}yoast_indexable'");
+  $updateIndex = $hasIndexTable && $hasIndexTable->num_rows > 0;
+  $products = $db->query("SELECT ID,post_title FROM {$prefix}posts WHERE post_type='product'");
+  if($products){
+    while($p=$products->fetch_assoc()){
+      $id = intval($p['ID']);
+      $title = $db->real_escape_string($p['post_title']);
+      $desc  = $db->real_escape_string("خرید $title با بهترین قیمت از فروشگاه ما.");
+      $db->query("DELETE FROM {$prefix}postmeta WHERE post_id=$id AND meta_key='_yoast_wpseo_metadesc'");
+      $db->query("INSERT INTO {$prefix}postmeta(post_id,meta_key,meta_value) VALUES ($id,'_yoast_wpseo_metadesc','$desc')");
+      if($updateIndex){
+        $db->query("UPDATE {$prefix}yoast_indexable SET description='$desc' WHERE object_id=$id AND object_type='post'");
+      }
+    }
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+  case 'analytics':
+   $db = connect(); if(!$db) break;
+   $prefix = $_SESSION['db']['prefix'];
   $catRes = $db->query("SELECT COALESCE(pt.name,t.name) name,COUNT(tr.object_id) c FROM {$prefix}terms t JOIN {$prefix}term_taxonomy tt ON t.term_id=tt.term_id LEFT JOIN {$prefix}term_taxonomy ptt ON tt.parent=ptt.term_taxonomy_id LEFT JOIN {$prefix}terms pt ON ptt.term_id=pt.term_id JOIN {$prefix}term_relationships tr ON tr.term_taxonomy_id=tt.term_taxonomy_id WHERE tt.taxonomy='product_cat' GROUP BY name");
   $cat = array('labels'=>array(),'data'=>array());
   if($catRes){ while($r=$catRes->fetch_assoc()){ $cat['labels'][]=$r['name']; $cat['data'][]=$r['c']; }}
@@ -376,6 +593,64 @@ function secure_load_config(){
   $key = hash('sha256', $_SESSION['token'], true);
   $json = openssl_decrypt($enc, 'AES-256-CBC', $key, OPENSSL_RAW_DATA, $iv);
   return $json ? json_decode($json,true) : false;
+}
+
+function connect_local(){
+  if(!isset($_SESSION['logdb'])) return false;
+  $cfg = $_SESSION['logdb'];
+  try{ $mysqli = new mysqli($cfg['host'],$cfg['user'],$cfg['pass'],$cfg['name']); }
+  catch(mysqli_sql_exception $e){ return false; }
+  if($mysqli->connect_errno) return false;
+  $mysqli->set_charset('utf8mb4');
+  init_local_tables($mysqli,$cfg['prefix']);
+  return $mysqli;
+}
+
+function init_local_tables($db,$prefix){
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}logs (id INT AUTO_INCREMENT PRIMARY KEY, action VARCHAR(20), ip VARCHAR(45), ts DATETIME)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}users (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(191) UNIQUE, password_hash VARCHAR(255) NOT NULL, full_name VARCHAR(191), phone_number VARCHAR(20), role VARCHAR(50), status VARCHAR(20) DEFAULT 'active', permissions TEXT, created_at DATETIME, updated_at DATETIME)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}sessions (id INT AUTO_INCREMENT PRIMARY KEY, user_id INT, token VARCHAR(255), ip_address VARCHAR(45), device_info VARCHAR(191), expires_at DATETIME, FOREIGN KEY (user_id) REFERENCES {$prefix}users(id) ON DELETE CASCADE)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}clients (id INT AUTO_INCREMENT PRIMARY KEY, client_name VARCHAR(191), api_key VARCHAR(191), client_secret VARCHAR(191), redirect_uri TEXT, status VARCHAR(20))");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}user_logs (id INT AUTO_INCREMENT PRIMARY KEY, user_id INT, action VARCHAR(50), timestamp DATETIME, ip_address VARCHAR(45), FOREIGN KEY (user_id) REFERENCES {$prefix}users(id) ON DELETE CASCADE)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}password_resets (id INT AUTO_INCREMENT PRIMARY KEY, user_id INT, reset_token VARCHAR(255), expires_at DATETIME, FOREIGN KEY (user_id) REFERENCES {$prefix}users(id) ON DELETE CASCADE)");
+}
+
+function secure_save_local_config($data){
+  if(!isset($_SESSION['token'])) return;
+  $key = hash('sha256', $_SESSION['token'], true);
+  $iv = random_bytes(16);
+  $json = json_encode($data);
+  $enc = openssl_encrypt($json, 'AES-256-CBC', $key, OPENSSL_RAW_DATA, $iv);
+  file_put_contents(__DIR__.'/local_config.secure', base64_encode($iv.$enc));
+}
+
+function secure_load_local_config(){
+  if(!isset($_SESSION['token'])) return false;
+  $path = __DIR__.'/local_config.secure';
+  if(!file_exists($path)) return false;
+  $raw = base64_decode(file_get_contents($path));
+  $iv = substr($raw,0,16);
+  $enc = substr($raw,16);
+  $key = hash('sha256', $_SESSION['token'], true);
+  $json = openssl_decrypt($enc, 'AES-256-CBC', $key, OPENSSL_RAW_DATA, $iv);
+  return $json ? json_decode($json,true) : false;
+}
+
+function log_event($action){
+  $db = connect_local();
+  if(!$db) return;
+  $prefix = $_SESSION['logdb']['prefix'];
+  $ip = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
+  $uid = isset($_SESSION['user_id']) ? intval($_SESSION['user_id']) : 0;
+  $dt = new DateTime('now', new DateTimeZone('Asia/Tehran'));
+  $ts = $dt->format('Y-m-d H:i:s');
+  $stmt = $db->prepare("INSERT INTO {$prefix}user_logs(user_id, action, ip_address, timestamp) VALUES (?,?,?,?)");
+  if($stmt){
+    $stmt->bind_param('isss',$uid,$action,$ip,$ts);
+    $stmt->execute();
+    $stmt->close();
+  }
+  $db->close();
 }
 
 function compute_seo_score($title,$meta,$content,$keyword){

--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -1,0 +1,54 @@
+<?php
+class UserManager {
+    private $db;
+    private $prefix;
+    public function __construct($db,$prefix){
+        $this->db = $db;
+        $this->prefix = $prefix;
+    }
+    public function all(){
+        $rows = [];
+        $res = $this->db->query("SELECT id, username, role, status, DATE_FORMAT(created_at,'%Y-%m-%d %H:%i') as created_at FROM {$this->prefix}users ORDER BY id DESC");
+        if($res){ while($r = $res->fetch_assoc()){ $rows[] = $r; } }
+        return $rows;
+    }
+    public function get($id){
+        $stmt = $this->db->prepare("SELECT id, username, full_name, phone_number, role, status, permissions FROM {$this->prefix}users WHERE id=?");
+        $stmt->bind_param('i',$id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $data = $res ? $res->fetch_assoc() : null;
+        $stmt->close();
+        return $data;
+    }
+    public function create($data){
+        $hash = password_hash($data['password'], PASSWORD_BCRYPT);
+        $stmt = $this->db->prepare("INSERT INTO {$this->prefix}users(username,password_hash,full_name,phone_number,role,status,permissions,created_at,updated_at) VALUES (?,?,?,?,?,?,?,NOW(),NOW())");
+        $stmt->bind_param('sssssss', $data['username'],$hash,$data['full_name'],$data['phone_number'],$data['role'],$data['status'],$data['permissions']);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+    public function update($id,$data){
+        if(!empty($data['password'])){
+            $hash = password_hash($data['password'], PASSWORD_BCRYPT);
+            $stmt = $this->db->prepare("UPDATE {$this->prefix}users SET username=?,password_hash=?,full_name=?,phone_number=?,role=?,status=?,permissions=?,updated_at=NOW() WHERE id=?");
+            $stmt->bind_param('sssssssi',$data['username'],$hash,$data['full_name'],$data['phone_number'],$data['role'],$data['status'],$data['permissions'],$id);
+        }else{
+            $stmt = $this->db->prepare("UPDATE {$this->prefix}users SET username=?,full_name=?,phone_number=?,role=?,status=?,permissions=?,updated_at=NOW() WHERE id=?");
+            $stmt->bind_param('ssssssi',$data['username'],$data['full_name'],$data['phone_number'],$data['role'],$data['status'],$data['permissions'],$id);
+        }
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+    public function delete($id){
+        $stmt = $this->db->prepare("DELETE FROM {$this->prefix}users WHERE id=?");
+        $stmt->bind_param('i',$id);
+        $stmt->execute();
+        $aff = $stmt->affected_rows;
+        $stmt->close();
+        return $aff>0;
+    }
+}
+?>

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,49 @@
+-- Database schema for user management
+CREATE TABLE IF NOT EXISTS msw_users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(191) UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  full_name VARCHAR(191),
+  phone_number VARCHAR(20),
+  role VARCHAR(50) DEFAULT 'user',
+  status VARCHAR(20) DEFAULT 'active',
+  permissions TEXT,
+  created_at DATETIME,
+  updated_at DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS msw_sessions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT,
+  token VARCHAR(255),
+  ip_address VARCHAR(45),
+  device_info VARCHAR(191),
+  expires_at DATETIME,
+  FOREIGN KEY (user_id) REFERENCES msw_users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS msw_clients (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  client_name VARCHAR(191),
+  api_key VARCHAR(191),
+  client_secret VARCHAR(191),
+  redirect_uri TEXT,
+  status VARCHAR(20)
+);
+
+CREATE TABLE IF NOT EXISTS msw_user_logs (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT,
+  action VARCHAR(50),
+  timestamp DATETIME,
+  ip_address VARCHAR(45),
+  FOREIGN KEY (user_id) REFERENCES msw_users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS msw_password_resets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT,
+  reset_token VARCHAR(255),
+  expires_at DATETIME,
+  FOREIGN KEY (user_id) REFERENCES msw_users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- Add navbar profile menu for account management, personal logs, and logout while keeping settings as last tab
- Introduce per-user log modal and button in Users table with charted activity
- Store logs with Tehran timezone and expose `fetch_user_logs` endpoint; enlarge category distribution chart

## Testing
- `php -l index.php`
- `php -l ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb249a21088325b64e1143b7d0ebff