### PR TITLE
Add profile dropdown and user log modal

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -2,12 +2,14 @@
 session_start();
 header('Content-Type: application/json; charset=utf-8');
 
-$AUTH_TOKEN = '09128334246';
 $configFile = __DIR__.'/config.secure';
 require_once __DIR__.'/prompt_template.php';
+require_once __DIR__.'/classes/UserManager.php';
 $action = isset($_POST['action']) ? $_POST['action'] : '';
 
-if(!isset($_SESSION['auth']) && $action !== 'login'){
+$publicActions = array('login','db_connect','load_saved_config','local_db_connect',
+  'local_load_config','local_check_config','admin_init','admin_check');
+if(!isset($_SESSION['auth']) && !in_array($action,$publicActions)){
   http_response_code(401);
   echo json_encode(array('success'=>false,'message'=>'دسترسی غیرمجاز'));
   exit;
@@ -15,35 +17,40 @@ if(!isset($_SESSION['auth']) && $action !== 'login'){
 
 switch($action){
 case 'login':
-  $token = isset($_POST['token']) ? $_POST['token'] : '';
-  if($token === $AUTH_TOKEN){
+  $username = trim($_POST['username'] ?? '');
+  $password = $_POST['password'] ?? '';
+  $cfg = secure_load_local_config();
+  if(!$cfg){ echo json_encode(array('success'=>false,'message'=>'تنظیمات پایگاه داده سامانه موجود نیست')); break; }
+  try{ $db = new mysqli($cfg['host'],$cfg['user'],$cfg['pass'],$cfg['name']); }
+  catch(mysqli_sql_exception $e){ echo json_encode(array('success'=>false,'message'=>$e->getMessage())); break; }
+  if($db->connect_errno){ echo json_encode(array('success'=>false,'message'=>$db->connect_error)); break; }
+  $db->set_charset('utf8mb4');
+  init_local_tables($db,$cfg['prefix']);
+  $stmt = $db->prepare("SELECT id,username,password_hash,permissions FROM {$cfg['prefix']}users WHERE username=? AND status='active'");
+  $stmt->bind_param('s',$username);
+  $stmt->execute();
+  $res = $stmt->get_result();
+  $row = $res ? $res->fetch_assoc() : null;
+  $stmt->close();
+  if($row && password_verify($password,$row['password_hash'])){
     $_SESSION['auth'] = true;
-    $_SESSION['token'] = $token;
+    $_SESSION['user_id'] = intval($row['id']);
+    $_SESSION['username'] = $row['username'];
+    $_SESSION['permissions'] = $row['permissions'];
+    $_SESSION['logdb'] = $cfg;
+    log_event('login');
     echo json_encode(array('success'=>true));
   } else {
-    echo json_encode(array('success'=>false,'message'=>'توکن نامعتبر است'));
+    echo json_encode(array('success'=>false,'message'=>'ورود نامعتبر'));
   }
+  $db->close();
   break;
- case 'logout':
+case 'logout':
+  log_event('logout');
   session_destroy();
   echo json_encode(array('success'=>true));
   break;
-case 'read_wp_config':
-  $config_path = dirname(__DIR__).'/wp-config.php';
-  if(file_exists($config_path)){
-    $config = file_get_contents($config_path);
-    preg_match("/define\(\s*'DB_NAME',\s*'([^']+)'\s*\)/", $config, $m); $name = isset($m[1]) ? $m[1] : '';
-    preg_match("/define\(\s*'DB_USER',\s*'([^']+)'\s*\)/", $config, $m); $user = isset($m[1]) ? $m[1] : '';
-    preg_match("/define\(\s*'DB_PASSWORD',\s*'([^']+)'\s*\)/", $config, $m); $pass = isset($m[1]) ? $m[1] : '';
-    preg_match("/define\(\s*'DB_HOST',\s*'([^']+)'\s*\)/", $config, $m); $host = isset($m[1]) ? $m[1] : 'localhost';
-    preg_match("/\$table_prefix\s*=\s*'([^']+)'/", $config, $m); $prefix = isset($m[1]) ? $m[1] : 'wp_';
-    secure_save_config(compact('host','name','user','pass','prefix'));
-    echo json_encode(array('success'=>true,'name'=>$name,'user'=>$user,'pass'=>$pass,'host'=>$host,'prefix'=>$prefix));
-  } else {
-    echo json_encode(array('success'=>false,'message'=>'فایل wp-config.php پیدا نشد'));
-  }
-  break;
- case 'db_connect':
+case 'db_connect':
   $host = isset($_POST['host']) ? $_POST['host'] : '';
   $name = isset($_POST['name']) ? $_POST['name'] : '';
   $user = isset($_POST['user']) ? $_POST['user'] : '';
@@ -98,29 +105,188 @@ case 'save_licenses':
   if(file_put_contents($path,json_encode($licenses,JSON_UNESCAPED_UNICODE))!==false){ echo json_encode(array('success'=>true)); }
   else{ echo json_encode(array('success'=>false,'message'=>'ذخیره نشد')); }
   break;
+case 'local_db_connect':
+  $host = isset($_POST['host']) ? $_POST['host'] : '';
+  $name = isset($_POST['name']) ? $_POST['name'] : '';
+  $user = isset($_POST['user']) ? $_POST['user'] : '';
+  $pass = isset($_POST['pass']) ? $_POST['pass'] : '';
+  $prefix = isset($_POST['prefix']) ? $_POST['prefix'] : 'msw_';
+  try{ $mysqli = new mysqli($host,$user,$pass,$name); }
+  catch(mysqli_sql_exception $e){ echo json_encode(array('success'=>false,'message'=>$e->getMessage())); break; }
+  if($mysqli->connect_errno){ echo json_encode(array('success'=>false,'message'=>$mysqli->connect_error)); break; }
+  $mysqli->set_charset('utf8mb4');
+  $_SESSION['logdb']=array('host'=>$host,'name'=>$name,'user'=>$user,'pass'=>$pass,'prefix'=>$prefix);
+  secure_save_local_config($_SESSION['logdb']);
+  init_local_tables($mysqli,$prefix);
+  $mysqli->close();
+  echo json_encode(array('success'=>true));
+  break;
+case 'local_load_config':
+  $cfg = secure_load_local_config();
+  if($cfg){ echo json_encode(array('success'=>true,'host'=>$cfg['host'],'name'=>$cfg['name'],'user'=>$cfg['user'],'pass'=>$cfg['pass'],'prefix'=>$cfg['prefix'])); }
+  else{ echo json_encode(array('success'=>false)); }
+  break;
+case 'local_check_config':
+  $cfg = secure_load_local_config();
+  if(!$cfg){ echo json_encode(array('success'=>false,'message'=>'تنظیمات موجود نیست')); break; }
+  try{ $mysqli = new mysqli($cfg['host'],$cfg['user'],$cfg['pass'],$cfg['name']); }
+  catch(mysqli_sql_exception $e){ echo json_encode(array('success'=>false,'message'=>$e->getMessage())); break; }
+  if($mysqli->connect_errno){ echo json_encode(array('success'=>false,'message'=>$mysqli->connect_error)); }
+  else { $mysqli->close(); echo json_encode(array('success'=>true)); }
+  break;
+case 'fetch_user_logs':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $prefix = $_SESSION['logdb']['prefix'];
+  $uid = intval($_POST['id'] ?? 0);
+  $rows = array();
+  $stmt = $db->prepare("SELECT action, ip_address, country, city, isp, timestamp FROM {$prefix}user_logs WHERE user_id=? ORDER BY id DESC LIMIT 100");
+  if($stmt){
+    $stmt->bind_param('i',$uid);
+    $stmt->execute();
+    $res=$stmt->get_result();
+    while($r=$res->fetch_assoc()){ $rows[] = array('action'=>$r['action'],'ip'=>$r['ip_address'],'country'=>$r['country'],'city'=>$r['city'],'isp'=>$r['isp'],'ts'=>$r['timestamp']); }
+    $stmt->close();
+  }
+  $counts=array();
+  foreach($rows as $r){ $counts[$r['action']] = ($counts[$r['action']] ?? 0) + 1; }
+  $db->close();
+  echo json_encode(array('success'=>true,'data'=>$rows,'counts'=>$counts));
+  break;
+case 'logs_list':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $prefix = $_SESSION['logdb']['prefix'];
+  $rows = array();
+  $res = $db->query("SELECT user_id, action, ip_address, country, city, isp, timestamp FROM {$prefix}user_logs ORDER BY id DESC LIMIT 200");
+  if($res){ while($r=$res->fetch_assoc()){ $rows[]=$r; } }
+  $db->close();
+  echo json_encode(array('success'=>true,'data'=>$rows));
+  break;
+case 'load_api_settings':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false)); break; }
+  $prefix = $_SESSION['logdb']['prefix'];
+  $key = get_setting($db,$prefix,'ipify_key');
+  $db->close();
+  echo json_encode(array('success'=>true,'ipify'=>$key));
+  break;
+case 'save_api_settings':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false)); break; }
+  $prefix = $_SESSION['logdb']['prefix'];
+  $key = $_POST['ipify'] ?? '';
+  save_setting($db,$prefix,'ipify_key',$key);
+  $db->close();
+  echo json_encode(array('success'=>true));
+  break;
+case 'admin_check':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false)); break; }
+  $prefix = $_SESSION['logdb']['prefix'];
+  $res = $db->query("SELECT COUNT(*) AS c FROM {$prefix}users WHERE role='admin'");
+  $row = $res ? $res->fetch_assoc() : array('c'=>0);
+  $db->close();
+  echo json_encode(array('success'=>true,'exists'=>$row['c']>0));
+  break;
+case 'admin_init':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $username = trim($_POST['username'] ?? '');
+  $password = $_POST['password'] ?? '';
+  if(!$username || !$password){ echo json_encode(array('success'=>false,'message'=>'نام کاربری و رمز عبور الزامی است')); $db->close(); break; }
+  $data = array(
+    'username'=>$username,
+    'password'=>$password,
+    'full_name'=>'',
+    'phone_number'=>'',
+    'role'=>'admin',
+    'status'=>'active',
+    'permissions'=>''
+  );
+  $ok = $mgr->create($data);
+  echo json_encode(array('success'=>$ok,'message'=>$ok?'':'خطا در ذخیره'));
+  $db->close();
+  break;
+case 'users_list':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db, $_SESSION['logdb']['prefix']);
+  echo json_encode(array('success'=>true,'data'=>$mgr->all()));
+  $db->close();
+  break;
+case 'user_get':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $id = intval($_POST['id'] ?? 0);
+  $data = $mgr->get($id);
+  if($data){ echo json_encode(array('success'=>true,'data'=>$data)); }
+  else { echo json_encode(array('success'=>false,'message'=>'کاربر یافت نشد')); }
+  $db->close();
+  break;
+case 'user_create':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $username = trim($_POST['username'] ?? '');
+  $password = $_POST['password'] ?? '';
+  if(!$username || !$password){ echo json_encode(array('success'=>false,'message'=>'نام کاربری و رمز عبور الزامی است')); $db->close(); break; }
+  $data = array(
+    'username'=>$username,
+    'password'=>$password,
+    'full_name'=>$_POST['full_name'] ?? '',
+    'phone_number'=>$_POST['phone_number'] ?? '',
+    'role'=>$_POST['role'] ?? 'user',
+    'status'=>$_POST['status'] ?? 'active',
+    'permissions'=>$_POST['permissions'] ?? ''
+  );
+  $ok = $mgr->create($data);
+  echo json_encode(array('success'=>$ok,'message'=>$ok?'':'خطا در ذخیره'));
+  $db->close();
+  break;
+case 'user_update':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $id = intval($_POST['id'] ?? 0);
+  $username = trim($_POST['username'] ?? '');
+  if(!$id || !$username){ echo json_encode(array('success'=>false,'message'=>'داده نامعتبر')); $db->close(); break; }
+  $data = array(
+    'username'=>$username,
+    'password'=>$_POST['password'] ?? '',
+    'full_name'=>$_POST['full_name'] ?? '',
+    'phone_number'=>$_POST['phone_number'] ?? '',
+    'role'=>$_POST['role'] ?? 'user',
+    'status'=>$_POST['status'] ?? 'active',
+    'permissions'=>$_POST['permissions'] ?? ''
+  );
+  $ok = $mgr->update($id,$data);
+  echo json_encode(array('success'=>$ok,'message'=>$ok?'':'خطا در ذخیره'));
+  $db->close();
+  break;
+case 'user_delete':
+  $db = connect_local();
+  if(!$db){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); break; }
+  $mgr = new UserManager($db,$_SESSION['logdb']['prefix']);
+  $id = intval($_POST['id'] ?? 0);
+  $ok = $mgr->delete($id);
+  echo json_encode(array('success'=>$ok,'message'=>$ok?'':'حذف نشد'));
+  $db->close();
+  break;
 case 'list_products':
   $db = connect(); if(!$db) break;
   $prefix = $_SESSION['db']['prefix'];
-  $start = isset($_POST['start']) ? intval($_POST['start']) : 0;
-  $length = isset($_POST['length']) ? intval($_POST['length']) : 100;
-  $draw = isset($_POST['draw']) ? intval($_POST['draw']) : 0;
   try{
-    $totalRes = $db->query("SELECT COUNT(*) c FROM {$prefix}posts WHERE post_type='product' AND post_status='publish'");
-    $total = $totalRes ? intval($totalRes->fetch_assoc()['c']) : 0;
-    $sql = "SELECT ID,post_title,post_content,post_name FROM {$prefix}posts WHERE post_type='product' AND post_status='publish' LIMIT $start,$length";
-    $res = $db->query($sql);
+    $res = $db->query("SELECT ID,post_title,post_content,post_name FROM {$prefix}posts WHERE post_type='product' AND post_status='publish'");
     if(!$res){ throw new Exception($db->error); }
     $rows = array();
     $scheme = isset($_SERVER['REQUEST_SCHEME']) ? $_SERVER['REQUEST_SCHEME'] : 'http';
     $site = $scheme.'://'.$_SERVER['HTTP_HOST'];
     while($row = $res->fetch_assoc()){
         $id = $row['ID'];
-        $imgRes = $db->query(
-          "SELECT p2.guid FROM {$prefix}postmeta pm " .
-          "JOIN {$prefix}posts p2 ON p2.ID = pm.meta_value " .
-          "WHERE pm.post_id=$id AND pm.meta_key='_thumbnail_id' " .
-          "ORDER BY pm.meta_id DESC LIMIT 1"
-        );
+        $imgRes = $db->query("SELECT p2.guid FROM {$prefix}postmeta pm JOIN {$prefix}posts p2 ON p2.ID = pm.meta_value WHERE pm.post_id=$id AND pm.meta_key='_thumbnail_id' ORDER BY pm.meta_id DESC LIMIT 1");
         $imgRow = $imgRes ? $imgRes->fetch_assoc() : null; $image = ($imgRow && isset($imgRow['guid'])) ? $imgRow['guid'] : '';
         $priceRes = $db->query("SELECT meta_value FROM {$prefix}postmeta WHERE post_id=$id AND meta_key='_price'");
         $priceRow = $priceRes ? $priceRes->fetch_assoc() : null; $price = ($priceRow && isset($priceRow['meta_value'])) ? $priceRow['meta_value'] : '';
@@ -130,30 +296,22 @@ case 'list_products':
         $seoTitle='';$seoDesc='';
         if($metaRes){ while($m=$metaRes->fetch_assoc()){ if($m['meta_key']=='_yoast_wpseo_title') $seoTitle=$m['meta_value']; elseif($m['meta_key']=='_yoast_wpseo_metadesc') $seoDesc=$m['meta_value']; }}
         $score = compute_seo_score($seoTitle ?: $row['post_title'], $seoDesc, $row['post_content'], $row['post_title']);
-        $seoColor='secondary';
-        $seoText='ندارد';
-        if($row['post_content'] || $seoTitle || $seoDesc){
-          $seoText=$score;
-          if($score >= 70){ $seoColor='success'; }
-          elseif($score >= 40){ $seoColor='warning'; }
-          else { $seoColor='danger'; }
-        }
         $priceDisplay = ($price && $price !== '0') ? $price : 'بدون قیمت';
-        $stockDisplay = $stock=='instock' ? '<span class="badge bg-success">موجود</span>' : '<span class="badge bg-danger">ناموجود</span>';
+        $stockDisplay = $stock=='instock' ? 'موجود' : 'ناموجود';
         $productUrl = $site.'/product/'.$row['post_name'].'/';
         $rows[] = array(
-          '<img data-src="'.$image.'" width="50" height="50" class="lazy-img rounded" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="">',
-          $row['post_title'],
-          $priceDisplay,
-          $stockDisplay,
-          '<span class="badge bg-'.$seoColor.'">'.$seoText.'</span>',
-          '<button class="btn btn-sm btn-primary edit" data-id="'.$id.'">ویرایش</button>',
-          '<a class="btn btn-sm btn-outline-secondary" href="'.$productUrl.'" target="_blank">نمایش</a>'
+          'id'=>$id,
+          'image'=>$image,
+          'name'=>$row['post_title'],
+          'price'=>$priceDisplay,
+          'stock'=>$stockDisplay,
+          'seo'=>$score,
+          'link'=>$productUrl
         );
     }
-    echo json_encode(array('draw'=>$draw,'recordsTotal'=>$total,'recordsFiltered'=>$total,'data'=>$rows));
+    echo json_encode(array('success'=>true,'data'=>$rows));
   }catch(Exception $e){
-    echo json_encode(array('draw'=>$draw,'recordsTotal'=>0,'recordsFiltered'=>0,'data'=>array(),'error'=>$e->getMessage()));
+    echo json_encode(array('success'=>false,'message'=>$e->getMessage()));
   }finally{
     $db->close();
   }
@@ -249,6 +407,7 @@ case 'save_product':
   $id = intval($_POST['id']);
   $name = $db->real_escape_string($_POST['name']);
   $slug = $db->real_escape_string($_POST['slug']);
+  $old_slug = isset($_POST['old_slug']) ? $db->real_escape_string($_POST['old_slug']) : '';
   $desc = $db->real_escape_string($_POST['description']);
   $price = $db->real_escape_string($_POST['price']);
   $stock = $db->real_escape_string($_POST['stock_status']);
@@ -291,12 +450,95 @@ case 'save_product':
        }
      }
   }
+  $redirect_success = false;
+  if($old_slug && $old_slug !== $slug){
+    $check = $db->query("SHOW TABLES LIKE '{$prefix}yoast_redirects'");
+    if($check && $check->num_rows){
+      $oldPath = '/product/'.$old_slug.'/';
+      $newPath = '/product/'.$slug.'/';
+      if($db->query("INSERT INTO {$prefix}yoast_redirects (origin,target,type) VALUES ('$oldPath','$newPath','301')")){
+        $redirect_success = true;
+      }
+    }
+  }
+  echo json_encode(array('success'=>true,'redirect'=>$redirect_success));
+  $db->close();
+  break;
+
+case 'bulk_stock':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $status = ($_POST['status'] ?? '') === 'instock' ? 'instock' : 'outofstock';
+  $db->query("UPDATE {$prefix}postmeta SET meta_value='$status' WHERE meta_key='_stock_status'");
+  $db->query("INSERT INTO {$prefix}postmeta (post_id,meta_key,meta_value) SELECT ID,'_stock_status','$status' FROM {$prefix}posts p WHERE p.post_type='product' AND NOT EXISTS (SELECT 1 FROM {$prefix}postmeta pm WHERE pm.post_id=p.ID AND pm.meta_key='_stock_status')");
   echo json_encode(array('success'=>true));
   $db->close();
   break;
- case 'analytics':
+
+case 'bulk_price':
   $db = connect(); if(!$db) break;
   $prefix = $_SESSION['db']['prefix'];
+  $op = ($_POST['op'] ?? '') === 'dec' ? '-' : '+';
+  $type = ($_POST['type'] ?? '') === 'fixed' ? 'fixed' : 'percent';
+  $val = isset($_POST['value']) ? floatval($_POST['value']) : 0;
+  if($val==0){ echo json_encode(array('success'=>false,'message'=>'مقدار نامعتبر')); $db->close(); break; }
+  if($type==='percent'){
+    $factor = $op==='+' ? (1 + $val/100) : (1 - $val/100);
+    $db->query("UPDATE {$prefix}postmeta SET meta_value=ROUND(CAST(meta_value AS DECIMAL(10,2))*$factor,2) WHERE meta_key IN ('_price','_regular_price')");
+  }else{
+    $sign = $op==='+' ? '+' : '-';
+    $db->query("UPDATE {$prefix}postmeta SET meta_value=ROUND(CAST(meta_value AS DECIMAL(10,2)) $sign $val,2) WHERE meta_key IN ('_price','_regular_price')");
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+case 'bulk_seo_keywords':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $hasIndexTable = $db->query("SHOW TABLES LIKE '{$prefix}yoast_indexable'");
+  $updateIndex = $hasIndexTable && $hasIndexTable->num_rows > 0;
+  $products = $db->query("SELECT ID,post_title FROM {$prefix}posts WHERE post_type='product'");
+  if($products){
+    while($p=$products->fetch_assoc()){
+      $id = intval($p['ID']);
+      $title = $db->real_escape_string($p['post_title']);
+      $db->query("DELETE FROM {$prefix}postmeta WHERE post_id=$id AND meta_key IN ('_yoast_wpseo_metakeywords','_yoast_wpseo_focuskw')");
+      $db->query("INSERT INTO {$prefix}postmeta(post_id,meta_key,meta_value) VALUES ($id,'_yoast_wpseo_metakeywords','$title'),($id,'_yoast_wpseo_focuskw','$title')");
+      if($updateIndex){
+        $db->query("UPDATE {$prefix}yoast_indexable SET primary_focus_keyword='$title', meta_keywords='$title' WHERE object_id=$id AND object_type='post'");
+      }
+    }
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+case 'bulk_seo_desc':
+  $db = connect(); if(!$db) break;
+  $prefix = $_SESSION['db']['prefix'];
+  $hasIndexTable = $db->query("SHOW TABLES LIKE '{$prefix}yoast_indexable'");
+  $updateIndex = $hasIndexTable && $hasIndexTable->num_rows > 0;
+  $products = $db->query("SELECT ID,post_title FROM {$prefix}posts WHERE post_type='product'");
+  if($products){
+    while($p=$products->fetch_assoc()){
+      $id = intval($p['ID']);
+      $title = $db->real_escape_string($p['post_title']);
+      $desc  = $db->real_escape_string("خرید $title با بهترین قیمت از فروشگاه ما.");
+      $db->query("DELETE FROM {$prefix}postmeta WHERE post_id=$id AND meta_key='_yoast_wpseo_metadesc'");
+      $db->query("INSERT INTO {$prefix}postmeta(post_id,meta_key,meta_value) VALUES ($id,'_yoast_wpseo_metadesc','$desc')");
+      if($updateIndex){
+        $db->query("UPDATE {$prefix}yoast_indexable SET description='$desc' WHERE object_id=$id AND object_type='post'");
+      }
+    }
+  }
+  echo json_encode(array('success'=>true));
+  $db->close();
+  break;
+
+  case 'analytics':
+   $db = connect(); if(!$db) break;
+   $prefix = $_SESSION['db']['prefix'];
   $catRes = $db->query("SELECT COALESCE(pt.name,t.name) name,COUNT(tr.object_id) c FROM {$prefix}terms t JOIN {$prefix}term_taxonomy tt ON t.term_id=tt.term_id LEFT JOIN {$prefix}term_taxonomy ptt ON tt.parent=ptt.term_taxonomy_id LEFT JOIN {$prefix}terms pt ON ptt.term_id=pt.term_id JOIN {$prefix}term_relationships tr ON tr.term_taxonomy_id=tt.term_taxonomy_id WHERE tt.taxonomy='product_cat' GROUP BY name");
   $cat = array('labels'=>array(),'data'=>array());
   if($catRes){ while($r=$catRes->fetch_assoc()){ $cat['labels'][]=$r['name']; $cat['data'][]=$r['c']; }}
@@ -358,24 +600,99 @@ function connect(){
 }
 
 function secure_save_config($data){
-  if(!isset($_SESSION['token'])) return;
-  $key = hash('sha256', $_SESSION['token'], true);
-  $iv = random_bytes(16);
   $json = json_encode($data);
-  $enc = openssl_encrypt($json, 'AES-256-CBC', $key, OPENSSL_RAW_DATA, $iv);
-  file_put_contents(__DIR__.'/config.secure', base64_encode($iv.$enc));
+  file_put_contents(__DIR__.'/config.secure', $json);
 }
 
 function secure_load_config(){
-  if(!isset($_SESSION['token'])) return false;
   $path = __DIR__.'/config.secure';
   if(!file_exists($path)) return false;
-  $raw = base64_decode(file_get_contents($path));
-  $iv = substr($raw,0,16);
-  $enc = substr($raw,16);
-  $key = hash('sha256', $_SESSION['token'], true);
-  $json = openssl_decrypt($enc, 'AES-256-CBC', $key, OPENSSL_RAW_DATA, $iv);
+  $json = file_get_contents($path);
   return $json ? json_decode($json,true) : false;
+}
+
+function connect_local(){
+  if(!isset($_SESSION['logdb'])) return false;
+  $cfg = $_SESSION['logdb'];
+  try{ $mysqli = new mysqli($cfg['host'],$cfg['user'],$cfg['pass'],$cfg['name']); }
+  catch(mysqli_sql_exception $e){ return false; }
+  if($mysqli->connect_errno) return false;
+  $mysqli->set_charset('utf8mb4');
+  init_local_tables($mysqli,$cfg['prefix']);
+  return $mysqli;
+}
+
+function init_local_tables($db,$prefix){
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}logs (id INT AUTO_INCREMENT PRIMARY KEY, action VARCHAR(20), ip VARCHAR(45), ts DATETIME)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}users (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(191) UNIQUE, password_hash VARCHAR(255) NOT NULL, full_name VARCHAR(191), phone_number VARCHAR(20), role VARCHAR(50), status VARCHAR(20) DEFAULT 'active', permissions TEXT, created_at DATETIME, updated_at DATETIME)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}sessions (id INT AUTO_INCREMENT PRIMARY KEY, user_id INT, token VARCHAR(255), ip_address VARCHAR(45), device_info VARCHAR(191), expires_at DATETIME, FOREIGN KEY (user_id) REFERENCES {$prefix}users(id) ON DELETE CASCADE)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}clients (id INT AUTO_INCREMENT PRIMARY KEY, client_name VARCHAR(191), api_key VARCHAR(191), client_secret VARCHAR(191), redirect_uri TEXT, status VARCHAR(20))");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}user_logs (id INT AUTO_INCREMENT PRIMARY KEY, user_id INT, action VARCHAR(50), timestamp DATETIME, ip_address VARCHAR(45), country VARCHAR(100), city VARCHAR(100), isp VARCHAR(191), FOREIGN KEY (user_id) REFERENCES {$prefix}users(id) ON DELETE CASCADE)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}password_resets (id INT AUTO_INCREMENT PRIMARY KEY, user_id INT, reset_token VARCHAR(255), expires_at DATETIME, FOREIGN KEY (user_id) REFERENCES {$prefix}users(id) ON DELETE CASCADE)");
+  $db->query("CREATE TABLE IF NOT EXISTS {$prefix}settings (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(191) UNIQUE, value TEXT)");
+}
+
+function get_setting($db,$prefix,$name){
+  $stmt = $db->prepare("SELECT value FROM {$prefix}settings WHERE name=?");
+  if(!$stmt) return null;
+  $stmt->bind_param('s',$name);
+  $stmt->execute();
+  $res = $stmt->get_result();
+  $row = $res ? $res->fetch_assoc() : null;
+  $stmt->close();
+  return $row ? $row['value'] : null;
+}
+
+function save_setting($db,$prefix,$name,$value){
+  $stmt = $db->prepare("INSERT INTO {$prefix}settings(name,value) VALUES(?,?) ON DUPLICATE KEY UPDATE value=VALUES(value)");
+  if(!$stmt) return false;
+  $stmt->bind_param('ss',$name,$value);
+  $ok = $stmt->execute();
+  $stmt->close();
+  return $ok;
+}
+
+function secure_save_local_config($data){
+  $json = json_encode($data);
+  file_put_contents(__DIR__.'/local_config.secure', $json);
+}
+
+function secure_load_local_config(){
+  $path = __DIR__.'/local_config.secure';
+  if(!file_exists($path)) return false;
+  $json = file_get_contents($path);
+  return $json ? json_decode($json,true) : false;
+}
+
+function log_event($action){
+  $db = connect_local();
+  if(!$db) return;
+  $prefix = $_SESSION['logdb']['prefix'];
+  $ip = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
+  $uid = isset($_SESSION['user_id']) ? intval($_SESSION['user_id']) : 0;
+  $dt = new DateTime('now', new DateTimeZone('Asia/Tehran'));
+  $ts = $dt->format('Y-m-d H:i:s');
+  $geo = array('country'=>'','city'=>'','isp'=>'');
+  $key = get_setting($db,$prefix,'ipify_key');
+  if($key){
+    $url = "https://geo.ipify.org/api/v2/country,city?apiKey={$key}&ip={$ip}";
+    $resp = @file_get_contents($url);
+    if($resp){
+      $data = json_decode($resp,true);
+      if($data){
+        $geo['country'] = $data['location']['country'] ?? '';
+        $geo['city'] = $data['location']['city'] ?? '';
+        $geo['isp'] = $data['isp'] ?? '';
+      }
+    }
+  }
+  $stmt = $db->prepare("INSERT INTO {$prefix}user_logs(user_id, action, ip_address, country, city, isp, timestamp) VALUES (?,?,?,?,?,?,?)");
+  if($stmt){
+    $stmt->bind_param('issssss',$uid,$action,$ip,$geo['country'],$geo['city'],$geo['isp'],$ts);
+    $stmt->execute();
+    $stmt->close();
+  }
+  $db->close();
 }
 
 function compute_seo_score($title,$meta,$content,$keyword){

--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -1,0 +1,54 @@
+<?php
+class UserManager {
+    private $db;
+    private $prefix;
+    public function __construct($db,$prefix){
+        $this->db = $db;
+        $this->prefix = $prefix;
+    }
+    public function all(){
+        $rows = [];
+        $res = $this->db->query("SELECT id, username, role, status, DATE_FORMAT(created_at,'%Y-%m-%d %H:%i') as created_at FROM {$this->prefix}users ORDER BY id DESC");
+        if($res){ while($r = $res->fetch_assoc()){ $rows[] = $r; } }
+        return $rows;
+    }
+    public function get($id){
+        $stmt = $this->db->prepare("SELECT id, username, full_name, phone_number, role, status, permissions FROM {$this->prefix}users WHERE id=?");
+        $stmt->bind_param('i',$id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $data = $res ? $res->fetch_assoc() : null;
+        $stmt->close();
+        return $data;
+    }
+    public function create($data){
+        $hash = password_hash($data['password'], PASSWORD_BCRYPT);
+        $stmt = $this->db->prepare("INSERT INTO {$this->prefix}users(username,password_hash,full_name,phone_number,role,status,permissions,created_at,updated_at) VALUES (?,?,?,?,?,?,?,NOW(),NOW())");
+        $stmt->bind_param('sssssss', $data['username'],$hash,$data['full_name'],$data['phone_number'],$data['role'],$data['status'],$data['permissions']);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+    public function update($id,$data){
+        if(!empty($data['password'])){
+            $hash = password_hash($data['password'], PASSWORD_BCRYPT);
+            $stmt = $this->db->prepare("UPDATE {$this->prefix}users SET username=?,password_hash=?,full_name=?,phone_number=?,role=?,status=?,permissions=?,updated_at=NOW() WHERE id=?");
+            $stmt->bind_param('sssssssi',$data['username'],$hash,$data['full_name'],$data['phone_number'],$data['role'],$data['status'],$data['permissions'],$id);
+        }else{
+            $stmt = $this->db->prepare("UPDATE {$this->prefix}users SET username=?,full_name=?,phone_number=?,role=?,status=?,permissions=?,updated_at=NOW() WHERE id=?");
+            $stmt->bind_param('ssssssi',$data['username'],$data['full_name'],$data['phone_number'],$data['role'],$data['status'],$data['permissions'],$id);
+        }
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+    public function delete($id){
+        $stmt = $this->db->prepare("DELETE FROM {$this->prefix}users WHERE id=?");
+        $stmt->bind_param('i',$id);
+        $stmt->execute();
+        $aff = $stmt->affected_rows;
+        $stmt->close();
+        return $aff>0;
+    }
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,7 +1,13 @@
 <?php
 session_start();
+$hasLocalConfig = file_exists(__DIR__.'/local_config.secure');
 $loggedIn = isset($_SESSION['auth']) && $_SESSION['auth'] === true;
 $dbConnected = isset($_SESSION['db']);
+$logDbConnected = isset($_SESSION['logdb']);
+$permissions = isset($_SESSION['permissions']) ? explode(',', $_SESSION['permissions']) : [];
+$canViewSettings = in_array('view_settings',$permissions);
+$canEditSlug = in_array('edit_slug',$permissions);
+$canViewLogs = in_array('view_logs',$permissions);
 ?>
 <!doctype html>
 <html lang="fa" dir="rtl">
@@ -9,15 +15,18 @@ $dbConnected = isset($_SESSION['db']);
 <meta charset="utf-8">
 <title>داشبورد مدیریت ووکامرس</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.rtl.min.css" rel="stylesheet">
-<link href="https://cdn.jsdelivr.net/npm/datatables.net-bs5@1.13.8/css/dataTables.bootstrap5.min.css" rel="stylesheet">
 <link href="https://cdn.jsdelivr.net/npm/@sweetalert2/theme-bootstrap-4@5/bootstrap-4.min.css" rel="stylesheet">
 <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Vazirmatn&display=swap" rel="stylesheet">
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css">
+<link rel="stylesheet" href="https://unpkg.com/gridjs/dist/theme/mermaid.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4/animate.min.css"/>
 <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/datatables.net@1.13.8/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/datatables.net-bs5@1.13.8/js/dataTables.bootstrap5.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
+<script src="https://unpkg.com/gridjs/dist/gridjs.umd.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
@@ -27,8 +36,8 @@ $dbConnected = isset($_SESSION['db']);
 <style>
 body {font-family:'Vazirmatn', sans-serif; background-color:#f7f7f7;}
 #login-box, #db-box {max-width:400px; margin-top:100px;}
-.navbar-brand{padding:0 .75rem;}
-#logout{margin:0 .75rem;}
+.navbar-brand{padding:0 .75rem;margin-right:1rem;}
+#profileMenu{margin-left:1rem;}
 #pageTimer{margin-right:1rem; font-size:.85rem;}
 footer{font-size:.9rem;}
 #logPanel{max-height:200px; overflow-y:auto;}
@@ -37,24 +46,93 @@ footer{font-size:.9rem;}
 </head>
 <body>
 
-<?php if(!$loggedIn): ?>
+<?php if(!$hasLocalConfig): ?>
 <div class="container">
-<div id="login-box" class="mx-auto">
+<div id="setupWizard" class="mx-auto" style="max-width:500px;margin-top:60px;">
   <div class="card">
-    <div class="card-header text-center">ورود با توکن</div>
+    <div class="card-header text-center">راه‌اندازی سامانه</div>
     <div class="card-body">
-      <div class="mb-3">
-        <label class="form-label">توکن امنیتی</label>
-        <input type="password" id="token" class="form-control">
+      <div id="step1">
+        <h5 class="mb-3">اتصال به پایگاه ووکامرس</h5>
+        <div class="mb-3"><label class="form-label">نام میزبان</label><input type="text" id="db_host" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">نام پایگاه</label><input type="text" id="db_name" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">نام کاربری</label><input type="text" id="db_user" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">رمز عبور</label><input type="password" id="db_pass" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">پیشوند جداول</label><input type="text" id="db_prefix" class="form-control" value="wp_"></div>
+        <div class="d-flex justify-content-end">
+          <button id="setup-next1" class="btn btn-primary">بعدی</button>
+        </div>
       </div>
-      <button id="login-btn" class="btn btn-primary w-100">ورود</button>
+      <div id="step2" class="d-none">
+        <h5 class="mb-3">اتصال پایگاه داده سامانه</h5>
+        <div class="mb-3"><label class="form-label">نام میزبان</label><input type="text" id="local_host" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">نام پایگاه</label><input type="text" id="local_name" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">نام کاربری</label><input type="text" id="local_user" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">رمز عبور</label><input type="password" id="local_pass" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">پیشوند جداول</label><input type="text" id="local_prefix" class="form-control" value="msw_"></div>
+        <div class="d-flex justify-content-between">
+          <button id="setup-back2" class="btn btn-secondary">قبلی</button>
+          <button id="setup-next2" class="btn btn-primary">بعدی</button>
+        </div>
+      </div>
+      <div id="step3" class="d-none">
+        <h5 class="mb-3">ایجاد مدیر سیستم</h5>
+        <div class="mb-3"><label class="form-label">نام کاربری</label><input type="text" id="admin_username" class="form-control"></div>
+        <div class="mb-3"><label class="form-label">رمز عبور</label><input type="password" id="admin_password" class="form-control"></div>
+        <div class="d-flex justify-content-between">
+          <button id="setup-back3" class="btn btn-secondary">قبلی</button>
+          <button id="setup-finish" class="btn btn-success">اتمام</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+<script>
+$('#setup-next1').click(function(){
+  $.post('ajax.php',{action:'db_connect',host:$('#db_host').val(),name:$('#db_name').val(),user:$('#db_user').val(),pass:$('#db_pass').val(),prefix:$('#db_prefix').val()},function(r){
+    if(r.success){ $('#step1').addClass('d-none'); $('#step2').removeClass('d-none'); }
+    else{ Swal.fire('خطا',r.message,'error'); }
+  },'json');
+});
+$('#setup-back2').click(function(){ $('#step2').addClass('d-none'); $('#step1').removeClass('d-none'); });
+$('#setup-next2').click(function(){
+  $.post('ajax.php',{action:'local_db_connect',host:$('#local_host').val(),name:$('#local_name').val(),user:$('#local_user').val(),pass:$('#local_pass').val(),prefix:$('#local_prefix').val()},function(r){
+    if(r.success){ $('#step2').addClass('d-none'); $('#step3').removeClass('d-none'); }
+    else{ Swal.fire('خطا',r.message,'error'); }
+  },'json');
+});
+$('#setup-back3').click(function(){ $('#step3').addClass('d-none'); $('#step2').removeClass('d-none'); });
+$('#setup-finish').click(function(){
+  $.post('ajax.php',{action:'admin_init',username:$('#admin_username').val(),password:$('#admin_password').val()},function(r){
+    if(r.success){
+      Swal.fire('موفق','مدیر ایجاد شد، لطفاً وارد شوید','success').then(()=>{location.reload();});
+    }else{
+      Swal.fire('خطا',r.message,'error');
+    }
+  },'json');
+});
+</script>
+<?php elseif(!$loggedIn): ?>
+<div class="container">
+<div id="login-box" class="mx-auto animate__animated animate__fadeInDown">
+  <div class="card shadow-sm">
+    <div class="card-body text-center">
+      <i class="fa-brands fa-apple fa-3x mb-3"></i>
+      <div class="mb-3">
+        <input type="text" id="username" class="form-control text-center" placeholder="Apple ID">
+      </div>
+      <div class="mb-3">
+        <input type="password" id="password" class="form-control text-center" placeholder="Password">
+      </div>
+      <button id="login-btn" class="btn btn-dark w-100">ورود</button>
     </div>
   </div>
 </div>
 </div>
 <script>
 $('#login-btn').click(function(){
-   $.post('ajax.php',{action:'login',token:$('#token').val()},function(res){
+   $.post('ajax.php',{action:'login',username:$('#username').val(),password:$('#password').val()},function(res){
      if(res.success){
        location.reload();
      }else{
@@ -89,8 +167,7 @@ $('#login-btn').click(function(){
         <label class="form-label">پیشوند جداول</label>
         <input type="text" id="db_prefix" class="form-control" value="wp_">
       </div>
-      <div class="d-flex justify-content-between">
-        <button id="auto-config" class="btn btn-secondary">خواندن از wp-config.php</button>
+      <div class="d-flex justify-content-end">
         <button id="connect-btn" class="btn btn-primary">اتصال</button>
       </div>
     </div>
@@ -98,19 +175,6 @@ $('#login-btn').click(function(){
 </div>
 </div>
 <script>
-$('#auto-config').click(function(){
-   $.post('ajax.php',{action:'read_wp_config'},function(res){
-     if(res.success){
-       $('#db_host').val(res.host);
-       $('#db_name').val(res.name);
-       $('#db_user').val(res.user);
-      $('#db_pass').val(res.pass);
-       if(res.prefix){ $('#db_prefix').val(res.prefix); }
-     }else{
-       Swal.fire('خطا',res.message,'error');
-     }
-   },'json');
-});
 $(function(){
   $.post('ajax.php',{action:'load_saved_config'},function(res){
     if(res.success){
@@ -148,11 +212,78 @@ $('#connect-btn').click(function(){
 });
 </script>
 
+<?php elseif(!$logDbConnected): ?>
+<div class="container">
+<div id="localdb-box" class="mx-auto">
+  <div class="card">
+    <div class="card-header text-center">اتصال پایگاه داده سامانه</div>
+    <div class="card-body">
+      <div class="mb-3">
+        <label class="form-label">نام میزبان</label>
+        <input type="text" id="local_host" class="form-control">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">نام پایگاه</label>
+        <input type="text" id="local_name" class="form-control">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">نام کاربری</label>
+        <input type="text" id="local_user" class="form-control">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">رمز عبور</label>
+        <input type="password" id="local_pass" class="form-control">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">پیشوند جداول</label>
+        <input type="text" id="local_prefix" class="form-control" value="msw_">
+      </div>
+      <button id="local-connect-btn" class="btn btn-primary w-100">اتصال</button>
+    </div>
+  </div>
+</div>
+</div>
+<script>
+$(function(){
+  $.post('ajax.php',{action:'local_load_config'},function(res){
+    if(res.success){
+      $('#local_host').val(res.host);
+      $('#local_name').val(res.name);
+      $('#local_user').val(res.user);
+      $('#local_pass').val(res.pass);
+      $('#local_prefix').val(res.prefix);
+      $.post('ajax.php',{action:'local_db_connect',host:res.host,name:res.name,user:res.user,pass:res.pass,prefix:res.prefix},function(r){if(r.success){location.reload();}},'json');
+    }
+  },'json');
+});
+$('#local-connect-btn').click(function(){
+  $.post('ajax.php',{
+    action:'local_db_connect',
+    host:$('#local_host').val(),
+    name:$('#local_name').val(),
+    user:$('#local_user').val(),
+    pass:$('#local_pass').val(),
+    prefix:$('#local_prefix').val()
+  },function(res){
+    if(res.success){ location.reload(); }else{ Swal.fire('خطا',res.message,'error'); }
+  },'json');
+});
+</script>
 <?php else: ?>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark w-100">
-  <a class="navbar-brand" href="#"><i class="fa-solid fa-screwdriver-wrench me-2"></i>بخش مدیریت</a>
-  <span id="pageTimer" class="text-light ms-auto"></span>
-  <button class="btn btn-warning" id="logout"><i class="fa-solid fa-right-from-bracket ms-1"></i>خروج</button>
+  <a class="navbar-brand ms-3" href="#"><i class="fa-solid fa-screwdriver-wrench me-2"></i>بخش مدیریت</a>
+  <span id="pageTimer" class="text-light"></span>
+  <div class="dropdown ms-auto me-3 d-flex align-items-center">
+    <span class="text-light me-2"><?=$_SESSION['username']?></span>
+    <a class="nav-link dropdown-toggle text-light" href="#" id="profileMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa-solid fa-user"></i></a>
+    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
+      <li><a class="dropdown-item" href="#" id="myAccount">مدیریت حساب</a></li>
+      <li><a class="dropdown-item" href="#" id="myLogs">لاگ من</a></li>
+      <?php if($canViewSettings): ?><li><a class="dropdown-item" href="#" id="goSettings">تنظیمات</a></li><?php endif; ?>
+      <li><hr class="dropdown-divider"></li>
+      <li><a class="dropdown-item" href="#" id="logoutLink">خروج</a></li>
+    </ul>
+  </div>
 </nav>
 <div class="container-fluid mt-4">
 <ul class="nav nav-tabs" id="dashboardTabs" role="tablist">
@@ -163,15 +294,25 @@ $('#connect-btn').click(function(){
     <button class="nav-link" data-bs-toggle="tab" data-bs-target="#analytics" type="button">گزارش‌ها</button>
   </li>
   <li class="nav-item" role="presentation">
+    <button class="nav-link" data-bs-toggle="tab" data-bs-target="#bulk" type="button">اقدامات دست‌جمعی</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" data-bs-toggle="tab" data-bs-target="#users" type="button">کاربران</button>
+  </li>
+  <?php if($canViewLogs): ?>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" data-bs-toggle="tab" data-bs-target="#logs" type="button">لاگ ورود و خروج</button>
+  </li>
+  <?php endif; ?>
+  <?php if($canViewSettings): ?>
+  <li class="nav-item" role="presentation">
     <button class="nav-link" data-bs-toggle="tab" data-bs-target="#settings" type="button">تنظیمات</button>
   </li>
+  <?php endif; ?>
 </ul>
 <div class="tab-content mt-4">
 <div class="tab-pane fade show active p-3" id="products">
-<table id="products-table" class="table table-striped text-center align-middle">
-<thead><tr><th>تصویر</th><th>نام</th><th>قیمت</th><th>انبارداری</th><th>سئو</th><th>ویرایش</th><th>نمایش</th></tr></thead>
-<tbody></tbody>
-</table>
+<div id="productsGrid" class="ag-theme-alpine" style="height:400px;"></div>
 </div>
 <div class="tab-pane fade p-3" id="analytics">
   <section class="mb-5">
@@ -180,7 +321,7 @@ $('#connect-btn').click(function(){
     <div class="card-body">
       <div class="row g-4">
         <div class="col-lg-6 text-center">
-          <canvas id="catChart" class="mx-auto" style="max-height:300px"></canvas>
+          <canvas id="catChart" class="mx-auto" style="max-height:400px"></canvas>
         </div>
         <div class="col-lg-6">
           <table class="table table-sm table-striped" id="catTable">
@@ -247,34 +388,106 @@ $('#connect-btn').click(function(){
    </div>
   </section>
 </div>
-<div class="tab-pane fade p-3" id="settings">
-  <div class="row g-3">
-    <div class="col-md-4">
-      <div class="card section-card text-center" data-bs-toggle="modal" data-bs-target="#configModal">
-        <div class="card-body">
-          <i class="fa fa-database fa-2x mb-2"></i>
-          <div>تنظیمات پایگاه داده</div>
-        </div>
-      </div>
+  <div class="tab-pane fade p-3" id="bulk">
+  <div class="card mb-3">
+    <div class="card-header">مدیریت موجودی</div>
+    <div class="card-body">
+      <p class="text-muted small">موجود یا ناموجود کردن همه محصولات. این کار باعث جلوگیری از خرید در زمان تغییر قیمت می‌شود.</p>
+      <button class="btn btn-success me-2" id="bulkStockIn">موجود کردن همه محصولات</button>
+      <button class="btn btn-danger" id="bulkStockOut">ناموجود کردن همه محصولات</button>
     </div>
-    <div class="col-md-4">
-      <div class="card section-card text-center" data-bs-toggle="modal" data-bs-target="#promptModal">
-        <div class="card-body">
-          <i class="fa fa-robot fa-2x mb-2"></i>
-          <div>پرامپت هوش مصنوعی</div>
+  </div>
+  <div class="card mb-3">
+    <div class="card-header">تغییر قیمت دسته‌جمعی</div>
+    <div class="card-body">
+      <div class="row g-2 align-items-end">
+        <div class="col-md-3">
+          <label class="form-label">مقدار</label>
+          <input type="number" id="bulkPriceVal" class="form-control">
         </div>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="card section-card text-center" data-bs-toggle="modal" data-bs-target="#licenseModal">
-        <div class="card-body">
-          <i class="fa fa-key fa-2x mb-2"></i>
-          <div>لایسنس‌ها</div>
+        <div class="col-md-3">
+          <label class="form-label">نوع</label>
+          <select id="bulkPriceType" class="form-select">
+            <option value="percent">درصد</option>
+            <option value="fixed">عدد ثابت</option>
+          </select>
+        </div>
+        <div class="col-md-6">
+          <button class="btn btn-success me-2" id="bulkPriceInc">افزایش قیمت</button>
+          <button class="btn btn-danger" id="bulkPriceDec">کاهش قیمت</button>
         </div>
       </div>
     </div>
   </div>
+    <div class="card mb-3">
+      <div class="card-header">اقدامات دسته‌جمعی سئو</div>
+      <div class="card-body">
+        <div class="mb-3">
+          <button class="btn btn-primary" id="bulkSeoKeywords">کپی نام محصول در Meta Keywords</button>
+    </div>
+    <div class="mb-3">
+      <button class="btn btn-secondary" id="bulkSeoDesc">تولید توضیحات متا</button>
+    </div>
+  </div>
 </div>
+  </div>
+  <div class="tab-pane fade p-3" id="users">
+    <div class="d-flex justify-content-end mb-3">
+      <button class="btn btn-success" id="addUserBtn">کاربر جدید</button>
+    </div>
+    <div id="usersTable"></div>
+  </div>
+  <?php if($canViewLogs): ?>
+  <div class="tab-pane fade p-3" id="logs">
+    <div id="logsTable"></div>
+  </div>
+  <?php endif; ?>
+  <?php if($canViewSettings): ?>
+  <div class="tab-pane fade p-3" id="settings">
+    <div class="row g-3">
+      <div class="col-md-3">
+        <div class="card section-card text-center" data-bs-toggle="modal" data-bs-target="#configModal">
+          <div class="card-body">
+            <i class="fa fa-database fa-2x mb-2"></i>
+            <div>تنظیمات پایگاه داده</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card section-card text-center" data-bs-toggle="modal" data-bs-target="#localConfigModal">
+          <div class="card-body">
+            <i class="fa fa-database fa-2x mb-2"></i>
+            <div>پایگاه داده سامانه</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card section-card text-center" data-bs-toggle="modal" data-bs-target="#promptModal">
+          <div class="card-body">
+            <i class="fa fa-robot fa-2x mb-2"></i>
+            <div>پرامپت هوش مصنوعی</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card section-card text-center" data-bs-toggle="modal" data-bs-target="#licenseModal">
+          <div class="card-body">
+            <i class="fa fa-key fa-2x mb-2"></i>
+            <div>لایسنس‌ها</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card section-card text-center" data-bs-toggle="modal" data-bs-target="#apiModal">
+          <div class="card-body">
+            <i class="fa fa-globe fa-2x mb-2"></i>
+            <div>API ها</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <?php endif; ?>
 </div>
 </div>
 
@@ -297,7 +510,7 @@ $('#connect-btn').click(function(){
  </div>
 </footer>
  
- <div class="modal fade" id="configModal" tabindex="-1">
+<div class="modal fade" id="configModal" tabindex="-1">
   <div class="modal-dialog">
    <div class="modal-content">
     <div class="modal-header">
@@ -327,15 +540,51 @@ $('#connect-btn').click(function(){
       <input type="text" id="cfg_prefix" class="form-control">
      </div>
     </div>
-    <div class="modal-footer justify-content-between">
-     <button id="cfgReadWp" class="btn btn-secondary" type="button">خواندن از wp-config.php</button>
+    <div class="modal-footer">
      <button id="cfgSave" class="btn btn-primary" type="button">ذخیره</button>
     </div>
    </div>
   </div>
- </div>
+</div>
 
- <div class="modal fade" id="promptModal" tabindex="-1">
+<div class="modal fade" id="localConfigModal" tabindex="-1">
+ <div class="modal-dialog">
+  <div class="modal-content">
+   <div class="modal-header">
+    <h5 class="modal-title">تنظیمات پایگاه داده سامانه</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+   </div>
+   <div class="modal-body">
+    <div id="localCfgStatus" class="mb-3 small"></div>
+    <div class="mb-3">
+     <label class="form-label">نام میزبان</label>
+     <input type="text" id="localCfg_host" class="form-control">
+    </div>
+    <div class="mb-3">
+     <label class="form-label">نام پایگاه</label>
+     <input type="text" id="localCfg_name" class="form-control">
+    </div>
+    <div class="mb-3">
+     <label class="form-label">نام کاربری</label>
+     <input type="text" id="localCfg_user" class="form-control">
+    </div>
+    <div class="mb-3">
+     <label class="form-label">رمز عبور</label>
+     <input type="password" id="localCfg_pass" class="form-control">
+    </div>
+    <div class="mb-3">
+     <label class="form-label">پیشوند جداول</label>
+     <input type="text" id="localCfg_prefix" class="form-control">
+    </div>
+   </div>
+   <div class="modal-footer">
+    <button id="localCfgSave" class="btn btn-primary" type="button">ذخیره</button>
+   </div>
+  </div>
+ </div>
+</div>
+
+<div class="modal fade" id="promptModal" tabindex="-1">
   <div class="modal-dialog modal-lg">
    <div class="modal-content">
     <div class="modal-header">
@@ -350,9 +599,9 @@ $('#connect-btn').click(function(){
     </div>
    </div>
   </div>
- </div>
+</div>
 
- <div class="modal fade" id="licenseModal" tabindex="-1">
+<div class="modal fade" id="licenseModal" tabindex="-1">
   <div class="modal-dialog">
    <div class="modal-content">
     <div class="modal-header">
@@ -367,10 +616,117 @@ $('#connect-btn').click(function(){
      <button id="saveLicenses" class="btn btn-primary" type="button">ذخیره</button>
     </div>
    </div>
+</div>
+</div>
+
+<div class="modal fade" id="apiModal" tabindex="-1">
+ <div class="modal-dialog">
+  <div class="modal-content">
+   <div class="modal-header">
+    <h5 class="modal-title">تنظیمات API</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+   </div>
+   <div class="modal-body">
+    <div class="mb-3">
+     <label class="form-label">کلید Geo.IPify</label>
+     <input type="text" id="ipifyKey" class="form-control">
+    </div>
+   </div>
+   <div class="modal-footer">
+    <button id="saveApiSettings" class="btn btn-primary" type="button">ذخیره</button>
+   </div>
   </div>
  </div>
+</div>
 
- <div class="modal fade" id="editModal" tabindex="-1">
+<div class="modal fade" id="userModal" tabindex="-1">
+ <div class="modal-dialog">
+  <form id="userForm" class="modal-content">
+   <div class="modal-header">
+    <h5 class="modal-title">کاربر</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+   </div>
+   <div class="modal-body">
+    <input type="hidden" id="user_id">
+    <div class="mb-3">
+     <label class="form-label">نام کاربری/ایمیل</label>
+     <input type="text" id="user_username" class="form-control" required>
+    </div>
+    <div class="mb-3">
+     <label class="form-label">رمز عبور</label>
+     <input type="password" id="user_password" class="form-control">
+    </div>
+    <div class="mb-3">
+     <label class="form-label">نام کامل</label>
+     <input type="text" id="user_fullname" class="form-control">
+    </div>
+    <div class="mb-3">
+     <label class="form-label">شماره تلفن</label>
+     <input type="text" id="user_phone" class="form-control">
+    </div>
+    <div class="mb-3">
+     <label class="form-label">نقش</label>
+     <select id="user_role" class="form-select">
+      <option value="admin">مدیر</option>
+      <option value="client">مشتری</option>
+      <option value="user" selected>کاربر</option>
+     </select>
+    </div>
+    <div class="mb-3">
+     <label class="form-label">وضعیت</label>
+     <select id="user_status" class="form-select">
+      <option value="active" selected>فعال</option>
+      <option value="inactive">غیرفعال</option>
+      <option value="banned">مسدود</option>
+     </select>
+    </div>
+    <div class="mb-3">
+     <label class="form-label">دسترسی‌ها</label>
+     <div class="form-check">
+      <input class="form-check-input perm" type="checkbox" value="manage_products" id="perm_products">
+      <label class="form-check-label" for="perm_products">مدیریت محصولات</label>
+     </div>
+     <div class="form-check">
+     <input class="form-check-input perm" type="checkbox" value="view_logs" id="perm_logs">
+     <label class="form-check-label" for="perm_logs">مشاهده لاگ‌ها</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input perm" type="checkbox" value="manage_users" id="perm_users">
+      <label class="form-check-label" for="perm_users">مدیریت کاربران</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input perm" type="checkbox" value="view_settings" id="perm_settings">
+      <label class="form-check-label" for="perm_settings">مشاهده تنظیمات</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input perm" type="checkbox" value="edit_slug" id="perm_slug">
+      <label class="form-check-label" for="perm_slug">ویرایش نامک</label>
+    </div>
+    </div>
+   </div>
+   <div class="modal-footer">
+    <button type="submit" class="btn btn-primary">ذخیره</button>
+   </div>
+  </form>
+</div>
+</div>
+
+<div class="modal fade" id="logModal" tabindex="-1">
+ <div class="modal-dialog modal-lg">
+  <div class="modal-content">
+   <div class="modal-header">
+    <h5 class="modal-title">لاگ کاربر: <span id="logUser"></span></h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+   </div>
+   <div class="modal-body">
+    <canvas id="logChart" class="mb-3" style="max-height:300px"></canvas>
+    <div id="userLogTable" class="text-end" style="direction:ltr;"></div>
+   </div>
+  </div>
+ </div>
+</div>
+
+<div class="modal fade" id="editModal" tabindex="-1">
  <div class="modal-dialog modal-xl modal-dialog-scrollable">
   <div class="modal-content">
    <div class="modal-header">
@@ -385,10 +741,13 @@ $('#connect-btn').click(function(){
          <input type="text" id="prod_name" class="form-control">
        </div>
        <div class="mb-3">
-         <label class="form-label">نامک محصول</label>
-         <div class="input-group">
-           <input type="text" id="prod_slug" class="form-control" disabled>
+       <label class="form-label">نامک محصول</label>
+        <div class="input-group">
+           <input type="text" id="prod_slug" class="form-control" <?php if(!$canEditSlug) echo 'disabled';?>>
+           <?php if($canEditSlug): ?>
            <button class="btn btn-outline-secondary" type="button" id="editSlug">ویرایش</button>
+           <button class="btn btn-outline-secondary" type="button" id="genSlug">ایجاد نامک انگلیسی</button>
+           <?php endif; ?>
          </div>
        </div>
        <div class="mb-3">
@@ -447,15 +806,41 @@ $('#connect-btn').click(function(){
        </div>
      </form>
    </div>
-  <div class="modal-footer">
-     <a href="#" class="btn btn-secondary" target="_blank" id="viewProduct">نمایش محصول</a>
-     <button type="button" class="btn btn-success" id="saveBtn">ذخیره</button>
-   </div>
+ <div class="modal-footer">
+    <a href="#" class="btn btn-secondary" target="_blank" id="viewProduct">نمایش محصول</a>
+    <button type="button" class="btn btn-success" id="saveBtn">ذخیره</button>
   </div>
+ </div>
+</div>
+</div>
+
+<div class="modal fade" id="adminSetupModal" tabindex="-1">
+ <div class="modal-dialog">
+  <form id="adminSetupForm" class="modal-content">
+   <div class="modal-header">
+    <h5 class="modal-title">ایجاد مدیر سامانه</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+   </div>
+   <div class="modal-body">
+    <div class="mb-3">
+     <label class="form-label">نام کاربری</label>
+     <input type="text" id="admin_username" class="form-control" required>
+    </div>
+    <div class="mb-3">
+     <label class="form-label">رمز عبور</label>
+     <input type="password" id="admin_password" class="form-control" required>
+    </div>
+   </div>
+   <div class="modal-footer">
+    <button type="submit" class="btn btn-primary">ثبت</button>
+   </div>
+  </form>
  </div>
 </div>
 
 <script>
+const currentUserId = <?= $_SESSION['user_id'] ?? 0 ?>;
+const myUsername = <?= json_encode($_SESSION['username'] ?? '') ?>;
 let licenses={};
 let descEditor, promptEditor;
 $.post('ajax.php',{action:'load_licenses'},function(res){
@@ -483,6 +868,26 @@ $('#copyPrompt').click(function(){
   toastr.info('کپی شد');
 });
 $('#editSlug').click(function(){ $('#prod_slug').prop('disabled',false).focus(); });
+$('#genSlug').click(function(){
+  const name = $('#prod_name').val();
+  if(!name){ toastr.error('نام محصول را وارد کنید'); return; }
+  NProgress.start();
+  $.ajax({
+    url:'https://api.mymemory.translated.net/get',
+    method:'GET',
+    data:{q:name, langpair:'fa|en'},
+    success:function(res){
+      NProgress.done();
+      if(res && res.responseData && res.responseData.translatedText){
+        let slug=res.responseData.translatedText.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'');
+        $('#prod_slug').val(slug);
+      }else{
+        toastr.error('ترجمه ناموفق بود');
+      }
+    },
+    error:function(){ NProgress.done(); toastr.error('ترجمه ناموفق بود'); }
+  });
+});
 
 $('#configModal').on('shown.bs.modal',function(){
   $('#cfgStatus').text('');
@@ -502,14 +907,6 @@ $('#configModal').on('shown.bs.modal',function(){
   },'json');
 });
 
-$('#cfgReadWp').click(function(){
-  $.post('ajax.php',{action:'read_wp_config'},function(res){
-    if(res.success){
-      $('#cfg_host').val(res.host); $('#cfg_name').val(res.name); $('#cfg_user').val(res.user); $('#cfg_pass').val(res.pass); if(res.prefix){ $('#cfg_prefix').val(res.prefix); }
-    }else{ Swal.fire('خطا',res.message,'error'); }
-  },'json');
-});
-
 $('#cfgSave').click(function(){
   $.post('ajax.php',{
     action:'db_connect',
@@ -520,6 +917,38 @@ $('#cfgSave').click(function(){
     prefix:$('#cfg_prefix').val()
   },function(res){
     if(res.success){ toastr.success('ذخیره شد'); $('#configModal').modal('hide'); location.reload(); }
+    else{ Swal.fire('خطا',res.message,'error'); }
+  },'json');
+});
+
+$('#localConfigModal').on('shown.bs.modal',function(){
+  $('#localCfgStatus').text('');
+  $.post('ajax.php',{action:'local_load_config'},function(res){
+    if(res.success){
+      $('#localCfg_host').val(res.host);
+      $('#localCfg_name').val(res.name);
+      $('#localCfg_user').val(res.user);
+      $('#localCfg_pass').val(res.pass);
+      $('#localCfg_prefix').val(res.prefix);
+    }
+  },'json');
+  $.post('ajax.php',{action:'local_check_config'},function(res){
+    const el=$('#localCfgStatus');
+    if(res.success){ el.text('اتصال برقرار است').removeClass('text-danger').addClass('text-success'); }
+    else { el.text(res.message).removeClass('text-success').addClass('text-danger'); }
+  },'json');
+});
+
+$('#localCfgSave').click(function(){
+  $.post('ajax.php',{
+    action:'local_db_connect',
+    host:$('#localCfg_host').val(),
+    name:$('#localCfg_name').val(),
+    user:$('#localCfg_user').val(),
+    pass:$('#localCfg_pass').val(),
+    prefix:$('#localCfg_prefix').val()
+  },function(res){
+    if(res.success){ toastr.success('ذخیره شد'); $('#localConfigModal').modal('hide'); location.reload(); }
     else{ Swal.fire('خطا',res.message,'error'); }
   },'json');
 });
@@ -543,6 +972,16 @@ $('#savePrompt').click(function(){
 
 $('#licenseModal').on('shown.bs.modal',function(){
   $.post('ajax.php',{action:'load_licenses'},function(res){ renderLicenses(res.success?res.data:{}); },'json');
+});
+
+$('#apiModal').on('shown.bs.modal',function(){
+  $.post('ajax.php',{action:'load_api_settings'},function(res){ if(res.success){ $('#ipifyKey').val(res.ipify); } },'json');
+});
+$('#saveApiSettings').click(function(){
+  $.post('ajax.php',{action:'save_api_settings',ipify:$('#ipifyKey').val()},function(res){
+    if(res.success){ toastr.success('ذخیره شد'); $('#apiModal').modal('hide'); }
+    else{ toastr.error('خطا'); }
+  },'json');
 });
 
 function renderLicenses(data){
@@ -631,33 +1070,23 @@ $('#copyLog').click(()=>{ navigator.clipboard.writeText($('#logPanel').text()); 
 $(document).ajaxStart(()=>NProgress.start());
 $(document).ajaxStop(()=>NProgress.done());
 
-const table = $('#products-table').DataTable({
-  serverSide:true,
-  processing:true,
-  pageLength:100,
-  searching:false,
-  language:{url:'//cdn.datatables.net/plug-ins/1.13.8/i18n/fa.json'},
-  ajax:{
-    url:'ajax.php',
-    type:'POST',
-    data:function(d){ d.action='list_products'; },
-    dataSrc:function(json){ log('products loaded: '+json.data.length); return json.data; },
-    error:function(xhr){ log('list_products ajax error '+xhr.status+' '+xhr.responseText); }
-  }
-});
-table.on('draw', initLazy);
-
-function initLazy(){
-  const imgs = document.querySelectorAll('img.lazy-img');
-  const observer = new IntersectionObserver((entries,obs)=>{
-    entries.forEach(e=>{
-      if(e.isIntersecting){
-        const img=e.target; img.src=img.dataset.src; obs.unobserve(img);
-      }
-    });
-  });
-  imgs.forEach(img=>observer.observe(img));
+const columnDefs=[
+ {headerName:'تصویر',field:'image',width:80,cellRenderer:params=>`<img src="${params.value}" width="50" height="50">`},
+ {headerName:'نام',field:'name',flex:1},
+ {headerName:'قیمت',field:'price',width:120},
+ {headerName:'انبارداری',field:'stock',width:120},
+ {headerName:'سئو',field:'seo',width:90},
+ {headerName:'ویرایش',field:'id',width:90,cellRenderer:params=>`<button class="btn btn-sm btn-primary edit" data-id="${params.value}">ویرایش</button>`},
+ {headerName:'نمایش',field:'link',width:90,cellRenderer:params=>`<a class="btn btn-sm btn-outline-secondary" target="_blank" href="${params.value}">نمایش</a>`}
+];
+const gridOptions={columnDefs:columnDefs,rowData:[],defaultColDef:{resizable:true}};
+const gridDiv=document.querySelector('#productsGrid');
+new agGrid.Grid(gridDiv,gridOptions);
+function loadProducts(){
+ fetch('ajax.php',{method:'POST',headers:{"Content-Type":"application/x-www-form-urlencoded"},body:'action=list_products'})
+ .then(r=>r.json()).then(r=>{ if(r.success){ gridOptions.api.setRowData(r.data); }});
 }
+loadProducts();
 
 $(document).on('click','.edit',function(){
  var id=$(this).data('id');
@@ -666,7 +1095,7 @@ $(document).on('click','.edit',function(){
     $('#prod_id').val(res.product.id);
     $('#modalProdName').text(res.product.name);
     $('#prod_name').val(res.product.name);
-    $('#prod_slug').val(res.product.slug).prop('disabled',true);
+    $('#prod_slug').val(res.product.slug).data('old',res.product.slug).prop('disabled',true);
     descEditor.setData(res.product.description);
     $('#prod_desc_html').val(res.product.description);
     $('#prod_price').val(res.product.price ? res.product.price.replace(/\B(?=(\d{3})+(?!\d))/g,',') : '');
@@ -704,6 +1133,7 @@ $('#saveBtn').click(function(){
         id:$('#prod_id').val(),
         name:$('#prod_name').val(),
         slug:$('#prod_slug').val(),
+        old_slug:$('#prod_slug').data('old'),
         description:descEditor.getData(),
         price:$('#prod_price').val().replace(/,/g,''),
         stock_status:$('#stock_status').val(),
@@ -715,6 +1145,14 @@ $('#saveBtn').click(function(){
         NProgress.done();
         if(res.success){
           toastr.success('با موفقیت ذخیره شد');
+          if($('#prod_slug').data('old')!==$('#prod_slug').val()){
+            if(res.redirect){
+              toastr.success('ریدایرکت 301 با موفقیت ثبت شد');
+            }else{
+              toastr.error('ثبت ریدایرکت با خطا مواجه شد');
+            }
+            $('#prod_slug').data('old',$('#prod_slug').val());
+          }
           table.ajax.reload(null,false);
           bootstrap.Modal.getInstance(document.getElementById('editModal')).hide();
         }else{
@@ -725,9 +1163,6 @@ $('#saveBtn').click(function(){
   });
 });
 
-$('#logout').click(function(){
- $.post('ajax.php',{action:'logout'},function(){location.reload();});
-});
 
 const startTime = Date.now();
 setInterval(()=>{
@@ -739,6 +1174,139 @@ setInterval(()=>{
 
 fetch('https://ipapi.co/json/').then(r=>r.json()).then(d=>{
   $('#ipInfo').html(`${d.ip} <img src="https://cdn.jsdelivr.net/npm/flag-icons@6.7.0/flags/4x3/${d.country_code.toLowerCase()}.svg" width="20" class="ms-1">`);
+});
+
+$('#bulkStockIn').click(function(){
+  Swal.fire({title:'آیا مطمئن هستید؟',text:'این کار باعث جلوگیری از خرید در زمان تغییر قیمت می‌شود.',icon:'warning',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_stock',status:'instock'},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('به‌روزرسانی شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
+});
+
+$('#bulkStockOut').click(function(){
+  Swal.fire({title:'آیا مطمئن هستید؟',text:'این کار باعث جلوگیری از خرید در زمان تغییر قیمت می‌شود.',icon:'warning',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_stock',status:'outofstock'},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('به‌روزرسانی شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
+});
+
+function bulkPrice(op){
+  const val=$('#bulkPriceVal').val();
+  if(!val){ toastr.error('مقدار را وارد کنید'); return; }
+  Swal.fire({title:'آیا مطمئن هستید؟',icon:'question',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_price',op:op,type:$('#bulkPriceType').val(),value:val},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('قیمت‌ها به‌روزرسانی شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
+}
+$('#bulkPriceInc').click(()=>bulkPrice('inc'));
+$('#bulkPriceDec').click(()=>bulkPrice('dec'));
+
+$('#bulkSeoKeywords').click(function(){
+  Swal.fire({title:'آیا مطمئن هستید؟',icon:'question',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_seo_keywords'},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('کلمات کلیدی به‌روزرسانی شد');}else{toastr.error(r.message);} 
+      },'json');
+    }
+  });
+});
+
+$('#bulkSeoDesc').click(function(){
+  Swal.fire({title:'آیا مطمئن هستید؟',icon:'question',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+    if(res.isConfirmed){
+      NProgress.start();
+      $.post('ajax.php',{action:'bulk_seo_desc'},function(r){
+        NProgress.done();
+        if(r.success){toastr.success('توضیحات متا تولید شد');}else{toastr.error(r.message);}
+      },'json');
+    }
+  });
+});
+
+function toJalali(d){
+  const date=new Date(d.replace(' ','T'));
+  return date.toLocaleString('fa-IR-u-ca-persian',{dateStyle:'short',timeStyle:'short'});
+}
+let logTable, logChart;
+function showUserLogs(id, name){
+  $.post('ajax.php',{action:'fetch_user_logs',id:id},function(r){
+    if(r.success){
+      $('#logUser').text(name);
+      const rows=r.data.map(d=>[toJalali(d.ts),d.action,d.ip,d.country,d.city,d.isp]);
+      if(!logTable){
+        logTable=new gridjs.Grid({columns:['زمان','عملیات','آی‌پی','کشور','شهر','ISP'],data:rows}).render(document.getElementById('userLogTable'));
+      }else{
+        logTable.updateConfig({data:rows}).forceRender();
+      }
+      const labels=Object.keys(r.counts), values=Object.values(r.counts);
+      if(logChart) logChart.destroy();
+      logChart=new Chart(document.getElementById('logChart'),{
+        type:'bar',
+        data:{labels:labels,datasets:[{label:'تعداد',data:values,backgroundColor:'#0d6efd'}]},
+        options:{plugins:{legend:{display:false}}}
+      });
+      $('#logModal').modal('show');
+    }else{
+      toastr.error(r.message);
+    }
+  },'json');
+}
+
+$('#usersTable').on('click','.user-log',function(){
+  const id=$(this).data('id');
+  const name=$(this).data('name');
+  showUserLogs(id,name);
+});
+
+$('#myLogs').click(function(e){
+  e.preventDefault();
+  showUserLogs(currentUserId,myUsername);
+});
+
+$('#goSettings').click(function(e){
+  e.preventDefault();
+  const tabEl=document.querySelector('#dashboardTabs button[data-bs-target="#settings"]');
+  if(tabEl) new bootstrap.Tab(tabEl).show();
+});
+
+$('#logoutLink').click(function(e){
+  e.preventDefault();
+  $.post('ajax.php',{action:'logout'},function(){location.reload();});
+});
+
+$('#myAccount').click(function(e){
+  e.preventDefault();
+  $.post('ajax.php',{action:'user_get',id:currentUserId},function(r){
+    if(r.success){
+      $('#user_id').val(r.data.id);
+      $('#user_username').val(r.data.username);
+      $('#user_fullname').val(r.data.full_name);
+      $('#user_phone').val(r.data.phone_number);
+      $('#user_role').val(r.data.role);
+      $('#user_status').val(r.data.status);
+      $('.perm').prop('checked',false);
+      if(r.data.permissions){ r.data.permissions.split(',').forEach(p=>$('.perm[value="'+p+'"]').prop('checked',true)); }
+      $('#user_password').val('');
+      $('#userModal').modal('show');
+    }else{ toastr.error(r.message); }
+  },'json');
 });
 
 // Analytics charts with tables
@@ -788,6 +1356,116 @@ let analyticsLoaded=false;
 $('button[data-bs-target="#analytics"]').on('shown.bs.tab',function(){
  if(!analyticsLoaded){ loadAnalytics(); analyticsLoaded=true; }
 });
+
+let usersGrid;
+$('#dashboardTabs button[data-bs-target="#users"]').on('shown.bs.tab',function(){
+ if(!usersGrid){
+  usersGrid=new gridjs.Grid({
+   columns:['ID','نام کاربری','نقش','وضعیت','ایجاد','اقدامات'],
+   server:{
+     url:'ajax.php',
+     method:'POST',
+     body:{action:'users_list'},
+     then:data=>data.data.map(u=>[u.id,u.username,u.role,u.status,u.created_at,gridjs.html(`<button class="btn btn-sm btn-info user-log" data-id="${u.id}" data-name="${u.username}">لاگ</button> <button class="btn btn-sm btn-primary edit-user" data-id="${u.id}">ویرایش</button> <button class="btn btn-sm btn-danger delete-user" data-id="${u.id}">حذف</button>`)] )
+   },
+   pagination:{limit:10}
+  }).render(document.getElementById('usersTable'));
+ } else { usersGrid.updateConfig({}).forceRender(); }
+});
+
+let logsGrid;
+$('#dashboardTabs button[data-bs-target="#logs"]').on('shown.bs.tab',function(){
+ if(!logsGrid){
+  logsGrid=new gridjs.Grid({
+   columns:['کاربر','عملیات','آی‌پی','کشور','شهر','ISP','زمان'],
+   server:{
+     url:'ajax.php',method:'POST',body:{action:'logs_list'},
+     then:data=>data.data.map(l=>[l.user_id,l.action,l.ip_address,l.country,l.city,l.isp,toJalali(l.timestamp)])
+   },
+   pagination:{limit:10}
+  }).render(document.getElementById('logsTable'));
+ } else { logsGrid.updateConfig({}).forceRender(); }
+});
+
+$('#addUserBtn').click(function(){
+ $('#userForm')[0].reset();
+ $('#user_id').val('');
+ $('.perm').prop('checked',false);
+ $('#userModal').modal('show');
+});
+
+$('#usersTable').on('click','.edit-user',function(){
+ const id=$(this).data('id');
+ $.post('ajax.php',{action:'user_get',id:id},function(r){
+  if(r.success){
+   $('#user_id').val(r.data.id);
+   $('#user_username').val(r.data.username);
+   $('#user_fullname').val(r.data.full_name);
+   $('#user_phone').val(r.data.phone_number);
+   $('#user_role').val(r.data.role);
+   $('#user_status').val(r.data.status);
+   $('.perm').prop('checked',false);
+   if(r.data.permissions){ r.data.permissions.split(',').forEach(p=>$('.perm[value="'+p+'"]').prop('checked',true)); }
+   $('#user_password').val('');
+   $('#userModal').modal('show');
+  } else { toastr.error(r.message); }
+ },'json');
+});
+
+$('#usersTable').on('click','.delete-user',function(){
+ const id=$(this).data('id');
+ Swal.fire({title:'حذف کاربر؟',icon:'warning',showCancelButton:true,confirmButtonText:'بله',cancelButtonText:'خیر'}).then(res=>{
+  if(res.isConfirmed){
+   $.post('ajax.php',{action:'user_delete',id:id},function(r){
+    if(r.success){ toastr.success('حذف شد'); usersGrid.updateConfig({}).forceRender(); }
+    else { toastr.error(r.message); }
+   },'json');
+  }
+ });
+});
+
+$('#userForm').submit(function(e){
+ e.preventDefault();
+ const perms=$('.perm:checked').map((i,el)=>el.value).get().join(',');
+ const data={
+  action: $('#user_id').val() ? 'user_update' : 'user_create',
+  id: $('#user_id').val(),
+  username: $('#user_username').val(),
+  password: $('#user_password').val(),
+  full_name: $('#user_fullname').val(),
+  phone_number: $('#user_phone').val(),
+  role: $('#user_role').val(),
+  status: $('#user_status').val(),
+  permissions: perms
+ };
+ $.post('ajax.php',data,function(r){
+  if(r.success){
+   toastr.success('ذخیره شد');
+   $('#userModal').modal('hide');
+   usersGrid.updateConfig({}).forceRender();
+  } else { toastr.error(r.message); }
+ },'json');
+});
+
+$(function(){
+  $.post('ajax.php',{action:'admin_check'},function(r){
+    if(r.success && !r.exists){
+      $('#adminSetupModal').modal({backdrop:'static',keyboard:false});
+      $('#adminSetupModal').modal('show');
+    }
+  },'json');
+});
+
+$('#adminSetupForm').submit(function(e){
+  e.preventDefault();
+  $.post('ajax.php',{action:'admin_init',username:$('#admin_username').val(),password:$('#admin_password').val()},function(r){
+    if(r.success){
+      toastr.success('مدیر ایجاد شد، لطفاً دوباره وارد شوید');
+      $.post('ajax.php',{action:'logout'},function(){ location.reload(); },'json');
+    } else { toastr.error(r.message); }
+  },'json');
+});
+
 </script>
 <?php endif; ?>
 </body>

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,58 @@
+-- Database schema for user management
+CREATE TABLE IF NOT EXISTS msw_users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(191) UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  full_name VARCHAR(191),
+  phone_number VARCHAR(20),
+  role VARCHAR(50) DEFAULT 'user',
+  status VARCHAR(20) DEFAULT 'active',
+  permissions TEXT,
+  created_at DATETIME,
+  updated_at DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS msw_sessions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT,
+  token VARCHAR(255),
+  ip_address VARCHAR(45),
+  device_info VARCHAR(191),
+  expires_at DATETIME,
+  FOREIGN KEY (user_id) REFERENCES msw_users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS msw_clients (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  client_name VARCHAR(191),
+  api_key VARCHAR(191),
+  client_secret VARCHAR(191),
+  redirect_uri TEXT,
+  status VARCHAR(20)
+);
+
+CREATE TABLE IF NOT EXISTS msw_user_logs (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT,
+  action VARCHAR(50),
+  timestamp DATETIME,
+  ip_address VARCHAR(45),
+  country VARCHAR(100),
+  city VARCHAR(100),
+  isp VARCHAR(191),
+  FOREIGN KEY (user_id) REFERENCES msw_users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS msw_password_resets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT,
+  reset_token VARCHAR(255),
+  expires_at DATETIME,
+  FOREIGN KEY (user_id) REFERENCES msw_users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS msw_settings (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(191) UNIQUE,
+  value TEXT
+);


### PR DESCRIPTION
## Summary
- Replace token login with user table authentication and show username in navbar
- Switch product listing to AG Grid and other tables to Grid.js with conditional slug editing and settings access
- Store Geo.IPify key in settings and log login locations with country, city, and ISP
- Add setup wizard for first-time database configuration and allow unauthenticated access for setup endpoints

## Testing
- `php -l index.php`
- `php -l ajax.php`
- `php -l classes/UserManager.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb249a21088325b64e1143b7d0ebff