### PR TITLE
Restrict products to assigned users and fetch Search Console stats

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -55,7 +55,7 @@ case 'login':
     $_SESSION['permissions'] = $row['permissions'];
     $_SESSION['logdb'] = $cfg;
     $mainCfg = secure_load_config();
-    if($mainCfg){ $_SESSION['db'] = $mainCfg; }
+  if($mainCfg){ $_SESSION['db'] = $mainCfg; }
     log_event('login');
     echo json_encode(array('success'=>true));
   } else {
@@ -609,12 +609,12 @@ case 'assign_manual':
   $inserted=0; $conflicts=array();
   foreach($arr as $pid){
     $check = $ldb->query("SELECT user_id FROM {$lp}product_assignments WHERE product_id=$pid");
-    if($check && $check->num_rows){
+  if($check && $check->num_rows){
       $assigned = intval($check->fetch_assoc()['user_id']);
       if($assigned != $user){ $conflicts[]=$pid; continue; }
     }
     $stmt = $ldb->prepare("INSERT INTO {$lp}product_assignments (user_id,product_id) VALUES (?,?)");
-    if($stmt){ $stmt->bind_param('ii',$user,$pid); if($stmt->execute()) $inserted++; $stmt->close(); }
+  if($stmt){ $stmt->bind_param('ii',$user,$pid); if($stmt->execute()) $inserted++; $stmt->close(); }
   }
   $ldb->close();
   if($conflicts){ echo json_encode(array('success'=>false,'message'=>'برخی محصولات قبلاً اختصاص یافته‌اند')); }
@@ -678,7 +678,7 @@ case 'user_assignments':
   if($ids){
     $idlist = implode(',',$ids);
     $pres = $db->query("SELECT ID,post_title FROM {$wp}posts WHERE ID IN ($idlist)");
-    if($pres){ while($p=$pres->fetch_assoc()){ $rows[] = array('id'=>$p['ID'],'title'=>$p['post_title']); } }
+  if($pres){ while($p=$pres->fetch_assoc()){ $rows[] = array('id'=>$p['ID'],'title'=>$p['post_title']); } }
   }
   $db->close();
   $ldb->close();
@@ -780,28 +780,30 @@ case 'list_products':
   $perm = $_SESSION['permissions'] ?? '';
   $query = "SELECT ID,post_title,post_content,post_name FROM {$prefix}posts WHERE post_type='product' AND post_status='publish'";
   if($perm !== 'all'){
-    $ldb = connect_local();
-    if(!$ldb){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); $db->close(); break; }
-    $lp = $_SESSION['logdb']['prefix'];
-    $uid = intval($_SESSION['user_id']);
-    $ids = array();
-    $ires = $ldb->query("SELECT product_id FROM {$lp}product_assignments WHERE user_id=$uid");
-    if($ires){ while($i=$ires->fetch_assoc()){ $ids[] = intval($i['product_id']); } $ires->close(); }
-    $ldb->close();
-    if($ids){
-      $query = "SELECT ID,post_title,post_content,post_name FROM {$prefix}posts WHERE ID IN (".implode(',',$ids).")";
+      $ldb = connect_local();
+      if(!$ldb){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); $db->close(); break; }
+      $lp = $_SESSION['logdb']['prefix'];
+      $uid = intval($_SESSION['user_id']);
+      $ids = array();
+      $ires = $ldb->query("SELECT product_id FROM {$lp}product_assignments WHERE user_id=$uid");
+      if($ires){ while($i=$ires->fetch_assoc()){ $ids[] = intval($i['product_id']); } $ires->close(); }
+      $ldb->close();
+      if($ids){
+        $query .= " AND ID IN (".implode(',', $ids).")";
+      }else{
+        // اگر هیچ تخصیصی وجود نداشته باشد هیچ محصولی نمایش داده نشود
+        $query .= " AND 1=0";
+      }
     }
-    // اگر هیچ تخصیصی وجود نداشته باشد همه محصولات نمایش داده می‌شوند
-  }
   try{
     $res = $db->query($query);
-    if(!$res){ throw new Exception($db->error); }
+  if(!$res){ throw new Exception($db->error); }
     $rows = array();
     $scheme = isset($_SERVER['REQUEST_SCHEME']) ? $_SERVER['REQUEST_SCHEME'] : 'http';
     $site = $scheme.'://'.$_SERVER['HTTP_HOST'];
     $scores = array();
     $ldb = connect_local();
-    if($ldb){
+  if($ldb){
       $lp = $_SESSION['logdb']['prefix'];
       $scRes = $ldb->query("SELECT product_id,score FROM {$lp}product_seo_scores");
       if($scRes){ while($sc=$scRes->fetch_assoc()){ $scores[intval($sc['product_id'])]=intval($sc['score']); } $scRes->close(); }
@@ -901,14 +903,14 @@ case 'get_product':
   $perm = $_SESSION['permissions'] ?? '';
   if($perm !== 'all'){
     $ldb = connect_local();
-    if(!$ldb){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); $db->close(); break; }
+  if(!$ldb){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); $db->close(); break; }
     $lp = $_SESSION['logdb']['prefix'];
     $uid = intval($_SESSION['user_id']);
     $check = $ldb->query("SELECT 1 FROM {$lp}product_assignments WHERE user_id=$uid AND product_id=$id");
     $allowed = ($check && $check->num_rows>0);
     $check && $check->close();
     $ldb->close();
-    if(!$allowed){ $db->close(); echo json_encode(array('success'=>false,'message'=>'دسترسی غیرمجاز')); break; }
+  if(!$allowed){ $db->close(); echo json_encode(array('success'=>false,'message'=>'دسترسی غیرمجاز')); break; }
   }
   $pRes = $db->query("SELECT post_title,post_content,post_name FROM {$prefix}posts WHERE ID=$id");
   $p = $pRes ? $pRes->fetch_assoc() : null;
@@ -994,14 +996,14 @@ case 'save_product':
   $perm = $_SESSION['permissions'] ?? '';
   if($perm !== 'all'){
     $ldb = connect_local();
-    if(!$ldb){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); $db->close(); break; }
+  if(!$ldb){ echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده سامانه')); $db->close(); break; }
     $lp = $_SESSION['logdb']['prefix'];
     $uid = intval($_SESSION['user_id']);
     $check = $ldb->query("SELECT 1 FROM {$lp}product_assignments WHERE user_id=$uid AND product_id=$id");
     $allowed = ($check && $check->num_rows>0);
     $check && $check->close();
     $ldb->close();
-    if(!$allowed){ $db->close(); echo json_encode(array('success'=>false,'message'=>'دسترسی غیرمجاز')); break; }
+  if(!$allowed){ $db->close(); echo json_encode(array('success'=>false,'message'=>'دسترسی غیرمجاز')); break; }
   }
   $name = $db->real_escape_string($_POST['name']);
   $slug = $db->real_escape_string($_POST['slug']);
@@ -1054,7 +1056,7 @@ case 'save_product':
   $redirect_success = false;
   if($old_slug && $old_slug !== $slug){
     $check = $db->query("SHOW TABLES LIKE '{$prefix}yoast_redirects'");
-    if($check && $check->num_rows){
+  if($check && $check->num_rows){
       $oldPath = '/'.$old_slug.'/';
       $newPath = '/'.$slug.'/';
       if($db->query("INSERT INTO {$prefix}yoast_redirects (origin,target,type) VALUES ('$oldPath','$newPath','301')")){
@@ -1071,7 +1073,7 @@ case 'save_product':
     $next = $vrow ? intval($vrow['v'])+1 : 1;
     $uid = intval($_SESSION['user_id']);
     $stmt = $ldb->prepare("INSERT INTO {$lp}product_content_history (product_id, old_content, new_content, changed_by, changed_at, version) VALUES (?,?,?,?,NOW(),?)");
-    if($stmt){
+  if($stmt){
       $stmt->bind_param('issii',$id,$oldContent,$desc,$uid,$next);
       $stmt->execute();
       $stmt->close();
@@ -1102,7 +1104,7 @@ case 'analyze_product_seo':
   if($ldb){
     $lp = $_SESSION['logdb']['prefix'];
     $stmt = $ldb->prepare("REPLACE INTO {$lp}product_seo_scores (product_id,score,details,analyzed_at) VALUES (?,?,?,NOW())");
-    if($stmt){ $det = json_encode($analysis['details'],JSON_UNESCAPED_UNICODE); $stmt->bind_param('iis',$id,$analysis['score'],$det); $stmt->execute(); $stmt->close(); }
+  if($stmt){ $det = json_encode($analysis['details'],JSON_UNESCAPED_UNICODE); $stmt->bind_param('iis',$id,$analysis['score'],$det); $stmt->execute(); $stmt->close(); }
     $ldb->close();
   }
   $db->close();
@@ -1213,7 +1215,7 @@ case 'sync_internal_links':
   if($cfg){
     try{ $wdb = new mysqli($cfg['host'],$cfg['user'],$cfg['pass'],$cfg['name']); }
     catch(mysqli_sql_exception $e){ $wdb = null; }
-    if($wdb && !$wdb->connect_errno){
+  if($wdb && !$wdb->connect_errno){
       $wdb->set_charset('utf8mb4');
       $wp = $cfg['prefix'];
       $base = '';
@@ -1538,7 +1540,7 @@ default:
 function connect(){
   if(!isset($_SESSION['db'])){
     $cfg = secure_load_config();
-    if(!$cfg){
+  if(!$cfg){
       echo json_encode(array('success'=>false,'message'=>'عدم اتصال به پایگاه داده'));
       return false;
     }
@@ -1575,7 +1577,7 @@ function secure_load_config(){
 function connect_local(){
   if(!isset($_SESSION['logdb'])){
     $cfg = secure_load_local_config();
-    if(!$cfg) return false;
+  if(!$cfg) return false;
     $_SESSION['logdb'] = $cfg;
   } else {
     $cfg = $_SESSION['logdb'];
@@ -1675,7 +1677,7 @@ function google_index_url($url){
   }
   if(!$token){
     $db = connect_local();
-    if($db){
+  if($db){
       $prefix = $_SESSION['logdb']['prefix'];
       $cid = get_setting($db,$prefix,'sc_client_id');
       $secret = get_setting($db,$prefix,'sc_client_secret');
@@ -1730,7 +1732,7 @@ function log_event($action){
   if($key){
     $url = "https://geo.ipify.org/api/v2/country,city?apiKey={$key}&ip={$ip}";
     $resp = @file_get_contents($url);
-    if($resp){
+  if($resp){
       $data = json_decode($resp,true);
       if($data){
         $geo['country'] = $data['location']['country'] ?? '';

--- a/classes/ProcessManager.php
+++ b/classes/ProcessManager.php
@@ -42,7 +42,7 @@ class ProcessManager {
         self::runSeoScore($steps);
         break;
       case 'gsc_fetch':
-        $steps[] = 'درخواست به Google API هنوز پیاده‌سازی نشده است';
+        self::runGscFetch($steps);
         break;
       default:
         $steps[] = 'فرایند ناشناخته';
@@ -103,6 +103,218 @@ class ProcessManager {
       $due = !$last || strtotime($last) + $interval*3600 <= time();
       if($due) self::run($p['name'],$steps);
     }
+  }
+  
+  private static function runGscFetch(&$steps){
+    $ldb = connect_local();
+    if(!$ldb){ $steps[]='اتصال پایگاه داده سامانه برقرار نشد'; return; }
+    $lp = $_SESSION['logdb']['prefix'];
+    $cid = self::getSetting($ldb,$lp,'sc_client_id');
+    $secret = self::getSetting($ldb,$lp,'sc_client_secret');
+    $refresh = self::getSetting($ldb,$lp,'sc_refresh_token');
+    $site = self::getSetting($ldb,$lp,'sc_site');
+    if(!$cid || !$secret || !$refresh || !$site){
+      $steps[]='تنظیمات سرچ کنسول ناقص است';
+      $ldb->close();
+      return;
+    }
+    $ch = curl_init('https://oauth2.googleapis.com/token');
+    curl_setopt_array($ch,array(
+      CURLOPT_POST=>true,
+      CURLOPT_POSTFIELDS=>http_build_query(array(
+        'client_id'=>$cid,
+        'client_secret'=>$secret,
+        'refresh_token'=>$refresh,
+        'grant_type'=>'refresh_token'
+      )),
+      CURLOPT_RETURNTRANSFER=>true
+    ));
+    $tok = curl_exec($ch);
+    curl_close($ch);
+    if($tok===false){ $steps[]='token request failed'; $ldb->close(); return; }
+    $tok=json_decode($tok,true);
+    $acc=$tok['access_token']??'';
+    if(!$acc){ $steps[]='access token missing'; $ldb->close(); return; }
+    $from=date('Y-m-d',strtotime('-7 days'));
+    $to=date('Y-m-d');
+    // request detailed search analytics for last 7 days grouped by required dimensions
+    // first request: max 5 dimensions (date,page,query,device,country)
+    $payload=json_encode(array(
+      'startDate'=>$from,
+      'endDate'=>$to,
+      'dimensions'=>array('date','page','query','device','country'),
+      'rowLimit'=>25000
+    ));
+    $ch=curl_init('https://searchconsole.googleapis.com/webmasters/v3/sites/'.urlencode($site).'/searchAnalytics/query');
+    curl_setopt_array($ch,array(
+      CURLOPT_POST=>true,
+      CURLOPT_HTTPHEADER=>array('Content-Type: application/json','Authorization: Bearer '.$acc),
+      CURLOPT_POSTFIELDS=>$payload,
+      CURLOPT_RETURNTRANSFER=>true
+    ));
+    $resp=curl_exec($ch);
+    $http=curl_getinfo($ch,CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if($resp===false || $http!=200){ $steps[]='API request failed'; $ldb->close(); return; }
+    $resp=json_decode($resp,true);
+    $rows1=$resp['rows']??array();
+
+    // second request for search appearance (date,page,query,device,searchAppearance)
+    $payload=json_encode(array(
+      'startDate'=>$from,
+      'endDate'=>$to,
+      'dimensions'=>array('date','page','query','device','searchAppearance'),
+      'rowLimit'=>25000
+    ));
+    $ch=curl_init('https://searchconsole.googleapis.com/webmasters/v3/sites/'.urlencode($site).'/searchAnalytics/query');
+    curl_setopt_array($ch,array(
+      CURLOPT_POST=>true,
+      CURLOPT_HTTPHEADER=>array('Content-Type: application/json','Authorization: Bearer '.$acc),
+      CURLOPT_POSTFIELDS=>$payload,
+      CURLOPT_RETURNTRANSFER=>true
+    ));
+    $resp=curl_exec($ch);
+    $http=curl_getinfo($ch,CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    $rows2=array();
+    if($resp===false || $http!=200){
+      $steps[]='searchAppearance fetch failed';
+    }else{
+      $resp=json_decode($resp,true);
+      $rows2=$resp['rows']??array();
+    }
+
+    // ensure table exists for daily indexed metrics
+    $ldb->query("CREATE TABLE IF NOT EXISTS {$lp}search_console_daily (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      date DATE,
+      site_url VARCHAR(255),
+      page VARCHAR(2083),
+      query VARCHAR(255),
+      device VARCHAR(20),
+      country VARCHAR(10),
+      clicks INT,
+      impressions INT,
+      ctr DECIMAL(5,2),
+      position DECIMAL(8,2),
+      search_appearance VARCHAR(50),
+      sessions INT NULL,
+      bounce_rate DECIMAL(5,2) NULL,
+      avg_session_duration INT NULL,
+      conversions INT NULL,
+      lcp DECIMAL(6,3) NULL,
+      cls DECIMAL(5,3) NULL,
+      fid DECIMAL(6,3) NULL,
+      ttfb DECIMAL(6,3) NULL,
+      referring_domains INT NULL,
+      anchors TEXT NULL,
+      trends_interest INT NULL,
+      UNIQUE KEY uniq (date,site_url,page(191),query(191),device,country,search_appearance)
+    ) CHARACTER SET utf8mb4");
+
+    $stmt=$ldb->prepare("INSERT INTO {$lp}search_console_daily
+      (date,site_url,page,query,device,country,clicks,impressions,ctr,position,search_appearance,
+       sessions,bounce_rate,avg_session_duration,conversions,lcp,cls,fid,ttfb,referring_domains,anchors,trends_interest)
+      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+      ON DUPLICATE KEY UPDATE clicks=VALUES(clicks),impressions=VALUES(impressions),ctr=VALUES(ctr),position=VALUES(position),
+        sessions=VALUES(sessions),bounce_rate=VALUES(bounce_rate),avg_session_duration=VALUES(avg_session_duration),
+        conversions=VALUES(conversions),lcp=VALUES(lcp),cls=VALUES(cls),fid=VALUES(fid),ttfb=VALUES(ttfb),
+        referring_domains=VALUES(referring_domains),anchors=VALUES(anchors),trends_interest=VALUES(trends_interest)");
+
+    $data=array();
+    $index=array();
+    $sumClicks=0;$sumImpr=0;$sumPosWeighted=0;
+    foreach($rows1 as $r){
+      $keys=$r['keys'];
+      $date=$keys[0]??''; $page=$keys[1]??''; $query=$keys[2]??''; $device=$keys[3]??''; $country=$keys[4]??'';
+      $clicks=intval($r['clicks']??0); $impr=intval($r['impressions']??0); $pos=floatval($r['position']??0);
+      $ctr=$impr>0?round($clicks/$impr*100,2):0;
+
+      $key="$date|$page|$query|$device|$country";
+      $base="$date|$page|$query|$device";
+      $data[$key]=array(
+        'date'=>$date,'page'=>$page,'query'=>$query,'device'=>$device,'country'=>$country,
+        'clicks'=>$clicks,'impressions'=>$impr,'ctr'=>$ctr,'position'=>$pos,'appearance'=>''
+      );
+      $index[$base][]=$key;
+
+      $sumClicks+=$clicks; $sumImpr+=$impr; $sumPosWeighted+=$pos*$impr;
+    }
+
+    foreach($rows2 as $r){
+      $keys=$r['keys'];
+      $date=$keys[0]??''; $page=$keys[1]??''; $query=$keys[2]??''; $device=$keys[3]??''; $appearance=$keys[4]??'';
+      $base="$date|$page|$query|$device";
+      if(isset($index[$base])){
+        foreach($index[$base] as $k){ $data[$k]['appearance']=$appearance; }
+      }
+    }
+
+    foreach($data as $row){
+      // placeholders for external data; actual API integrations to be implemented
+      $ga=self::fetchAnalyticsMetrics($row['page'],$row['date']);
+      $ps=self::fetchPageSpeedMetrics($row['page']);
+      $bl=self::fetchBacklinkData($row['page']);
+      $tr=self::fetchTrendsInterest($row['query']);
+
+      $sess=$ga['sessions'];
+      $br=$ga['bounce_rate'];
+      $dur=$ga['avg_session_duration'];
+      $conv=$ga['conversions'];
+      $lcp=$ps['lcp'];
+      $cls=$ps['cls'];
+      $fid=$ps['fid'];
+      $ttfb=$ps['ttfb'];
+      $refDom=$bl['referring_domains'];
+      $anchors=$bl['anchors'];
+
+      $stmt->bind_param('ssssssiiddsidiiddddisi',
+        $row['date'],$site,$row['page'],$row['query'],$row['device'],$row['country'],$row['clicks'],$row['impressions'],$row['ctr'],$row['position'],$row['appearance'],
+        $sess,$br,$dur,$conv,$lcp,$cls,$fid,$ttfb,$refDom,$anchors,$tr);
+      $stmt->execute();
+    }
+    if($stmt){ $stmt->close(); }
+
+    $avgCtr=$sumImpr>0?round($sumClicks/$sumImpr*100,2):0;
+    $avgPos=$sumImpr>0?round($sumPosWeighted/$sumImpr,2):0;
+    $summary=array('start'=>$from,'end'=>$to,'clicks'=>$sumClicks,'impressions'=>$sumImpr,'ctr'=>$avgCtr,'position'=>$avgPos);
+    $json=json_encode($summary,JSON_UNESCAPED_UNICODE);
+    $stmt=$ldb->prepare("INSERT INTO {$lp}settings(name,value) VALUES('sc_last_summary',?) ON DUPLICATE KEY UPDATE value=VALUES(value)");
+    if($stmt){ $stmt->bind_param('s',$json); $stmt->execute(); $stmt->close(); }
+    $steps[]='داده‌های سرچ کنسول ذخیره شد';
+    $ldb->close();
+  }
+
+  // placeholder external data fetchers
+  private static function fetchAnalyticsMetrics($page,$date){
+    // TODO: integrate Google Analytics API
+    return array('sessions'=>null,'bounce_rate'=>null,'avg_session_duration'=>null,'conversions'=>null);
+  }
+
+  private static function fetchPageSpeedMetrics($page){
+    // TODO: integrate PageSpeed Insights or CrUX API
+    return array('lcp'=>null,'cls'=>null,'fid'=>null,'ttfb'=>null);
+  }
+
+  private static function fetchBacklinkData($page){
+    // TODO: integrate backlink provider API
+    return array('referring_domains'=>null,'anchors'=>null);
+  }
+
+  private static function fetchTrendsInterest($query){
+    // TODO: integrate Google Trends API
+    return null;
+  }
+
+  private static function getSetting($db,$prefix,$name){
+    $stmt=$db->prepare("SELECT value FROM {$prefix}settings WHERE name=?");
+    if(!$stmt) return null;
+    $stmt->bind_param('s',$name);
+    $stmt->execute();
+    $res=$stmt->get_result();
+    $row=$res?$res->fetch_assoc():null;
+    $stmt->close();
+    return $row?$row['value']:null;
   }
 }
 ?>

--- a/schema.sql
+++ b/schema.sql
@@ -121,3 +121,30 @@ CREATE TABLE IF NOT EXISTS msw_external_links (
   url TEXT,
   title VARCHAR(191)
 );
+
+CREATE TABLE IF NOT EXISTS msw_search_console_daily (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  date DATE,
+  site_url VARCHAR(255),
+  page VARCHAR(2083),
+  query VARCHAR(255),
+  device VARCHAR(20),
+  country VARCHAR(10),
+  clicks INT,
+  impressions INT,
+  ctr DECIMAL(5,2),
+  position DECIMAL(8,2),
+  search_appearance VARCHAR(50),
+  sessions INT NULL,
+  bounce_rate DECIMAL(5,2) NULL,
+  avg_session_duration INT NULL,
+  conversions INT NULL,
+  lcp DECIMAL(6,3) NULL,
+  cls DECIMAL(5,3) NULL,
+  fid DECIMAL(6,3) NULL,
+  ttfb DECIMAL(6,3) NULL,
+  referring_domains INT NULL,
+  anchors TEXT NULL,
+  trends_interest INT NULL,
+  UNIQUE KEY uniq (date,site_url,page(191),query(191),device,country,search_appearance)
+);


### PR DESCRIPTION
## Summary
- show only products assigned to user unless they have all permissions
- hide all products when user has no assignments
- implement process to fetch Google Search Console metrics and store summary
- store detailed Search Console metrics per page/query/device/country for daily analysis
- split Search Console fetch into two requests to include search appearance within API dimension limits

## Testing
- `php -l ajax.php`
- `php -l classes/ProcessManager.php`


------
https://chatgpt.com/codex/tasks/task_e_68c55cfd5e3c8325ac98e614db075cf2